### PR TITLE
change service target config ordering

### DIFF
--- a/docs/usage/ServiceTargetConfigs.md
+++ b/docs/usage/ServiceTargetConfigs.md
@@ -56,8 +56,9 @@ Currently, supported values are:
 ## Priority
 
 The `spec.priority` field is an integer number specifying the scheduling priority for the ServiceTargetConfig. 
-ServiceTargetConfigs with a higher priority number will be prioritized over those ServiceTargetConfigs with a lower priority.
-If the priority of two ServiceTarget configs is the same, the one with the lower number of Instances references will be prioritized.
+To calculate the effective priority when scheduling Instances is calculated by dividing the specified priority by the number of instance references
+(`spec.priority/(len(status.InstanceRegs) + 1)`).
+The more instances that are referenced by a ServiceTargetConfig, the lower the effective priority becomes.
 
 
 ## Secret Reference

--- a/docs/usage/ServiceTargetConfigs.md
+++ b/docs/usage/ServiceTargetConfigs.md
@@ -57,7 +57,7 @@ Currently, supported values are:
 
 The `spec.priority` field is an integer number specifying the scheduling priority for the ServiceTargetConfig. 
 To calculate the effective priority when scheduling Instances is calculated by dividing the specified priority by the number of instance references
-(`spec.priority/(len(status.InstanceRegs) + 1)`).
+(`spec.priority/(len(status.instanceRefs) + 1)`).
 The more instances that are referenced by a ServiceTargetConfig, the lower the effective priority becomes.
 
 

--- a/pkg/controllers/landscaperdeployments/reconcile_test.go
+++ b/pkg/controllers/landscaperdeployments/reconcile_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/gardener/landscaper-service/test/utils/envtest"
 )
 
-var _ = Describe("FilterServiceTargetConfigs", func() {
+var _ = Describe("SortServiceTargetConfigs", func() {
 	It("should sort descending by priority", func() {
 		configs := &lssv1alpha1.ServiceTargetConfigList{
 			Items: []lssv1alpha1.ServiceTargetConfig{
@@ -45,7 +45,7 @@ var _ = Describe("FilterServiceTargetConfigs", func() {
 			},
 		}
 
-		deploymentscontroller.FilterServiceTargetConfigs(configs)
+		deploymentscontroller.SortServiceTargetConfigs(configs)
 		Expect(configs.Items).To(HaveLen(3))
 		Expect(configs.Items[0].Spec.Priority).To(Equal(int64(30)))
 		Expect(configs.Items[1].Spec.Priority).To(Equal(int64(20)))
@@ -102,7 +102,7 @@ var _ = Describe("FilterServiceTargetConfigs", func() {
 			},
 		}
 
-		deploymentscontroller.FilterServiceTargetConfigs(configs)
+		deploymentscontroller.SortServiceTargetConfigs(configs)
 		Expect(configs.Items).To(HaveLen(3))
 		Expect(configs.Items[0].GetName()).To(Equal("second"))
 		Expect(configs.Items[1].GetName()).To(Equal("first"))
@@ -117,7 +117,7 @@ var _ = Describe("FilterServiceTargetConfigs", func() {
 						Name: "first",
 					},
 					Spec: lssv1alpha1.ServiceTargetConfigSpec{
-						Priority: 20,
+						Priority: 30,
 					},
 					Status: lssv1alpha1.ServiceTargetConfigStatus{
 						InstanceRefs: []lssv1alpha1.ObjectReference{
@@ -141,7 +141,7 @@ var _ = Describe("FilterServiceTargetConfigs", func() {
 						Name: "third",
 					},
 					Spec: lssv1alpha1.ServiceTargetConfigSpec{
-						Priority: 30,
+						Priority: 40,
 					},
 					Status: lssv1alpha1.ServiceTargetConfigStatus{
 						InstanceRefs: []lssv1alpha1.ObjectReference{
@@ -159,11 +159,11 @@ var _ = Describe("FilterServiceTargetConfigs", func() {
 			},
 		}
 
-		deploymentscontroller.FilterServiceTargetConfigs(configs)
+		deploymentscontroller.SortServiceTargetConfigs(configs)
 		Expect(configs.Items).To(HaveLen(3))
-		Expect(configs.Items[0].GetName()).To(Equal("third"))
-		Expect(configs.Items[1].GetName()).To(Equal("second"))
-		Expect(configs.Items[2].GetName()).To(Equal("first"))
+		Expect(configs.Items[0].GetName()).To(Equal("second"))
+		Expect(configs.Items[1].GetName()).To(Equal("first"))
+		Expect(configs.Items[2].GetName()).To(Equal("third"))
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Service target configs are now sorted by their priority divided by the number of instances that are using the config.

With this change the Instances will be more evenly distributed accross all ServiceTargetConfigs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
ServiceTargetConfigs are now scheduled by their effective priority. The effective priority is calculated by the specified priority divided by the number of referenced instances.
```
