### PR TITLE
generate fixed length hosting cluster namespace

### DIFF
--- a/pkg/apis/.schemes/core-v1alpha1-Instance.json
+++ b/pkg/apis/.schemes/core-v1alpha1-Instance.json
@@ -43,10 +43,17 @@
       "description": "InstanceSpec contains the specification for an Instance.",
       "type": "object",
       "required": [
+        "tenantId",
+        "id",
         "landscaperConfiguration",
         "serviceTargetConfigRef"
       ],
       "properties": {
+        "id": {
+          "description": "ID is the id of this instance",
+          "type": "string",
+          "default": ""
+        },
         "landscaperConfiguration": {
           "description": "LandscaperConfiguration contains the configuration for the landscaper service deployment",
           "default": {},
@@ -56,6 +63,11 @@
           "description": "ServiceTargetConfigRef specifies the target cluster for which the installation is created.",
           "default": {},
           "$ref": "#/definitions/core-v1alpha1-ObjectReference"
+        },
+        "tenantId": {
+          "description": "TenantId is the unique identifier of the owning tenant.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/pkg/apis/.schemes/core-v1alpha1-LandscaperDeployment.json
+++ b/pkg/apis/.schemes/core-v1alpha1-LandscaperDeployment.json
@@ -60,6 +60,7 @@
       "description": "LandscaperDeploymentSpec contains the specification for a LandscaperDeployment.",
       "type": "object",
       "required": [
+        "tenantId",
         "purpose",
         "landscaperConfiguration"
       ],
@@ -77,6 +78,11 @@
         "region": {
           "description": "Region selects the region this LandscaperDeployment should be installed on.",
           "type": "string"
+        },
+        "tenantId": {
+          "description": "TenantId is the unique identifier of the owning tenant.",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/pkg/apis/core/type_instance.go
+++ b/pkg/apis/core/type_instance.go
@@ -37,6 +37,12 @@ type Instance struct {
 
 // InstanceSpec contains the specification for an Instance.
 type InstanceSpec struct {
+	// TenantId is the unique identifier of the owning tenant.
+	TenantId string `json:"tenantId"`
+
+	// ID is the id of this instance
+	ID string `json:"id"`
+
 	// LandscaperConfiguration contains the configuration for the landscaper service deployment
 	LandscaperConfiguration LandscaperConfiguration `json:"landscaperConfiguration"`
 

--- a/pkg/apis/core/type_landscaperdeployment.go
+++ b/pkg/apis/core/type_landscaperdeployment.go
@@ -35,6 +35,9 @@ type LandscaperDeployment struct {
 
 // LandscaperDeploymentSpec contains the specification for a LandscaperDeployment.
 type LandscaperDeploymentSpec struct {
+	// TenantId is the unique identifier of the owning tenant.
+	TenantId string `json:"tenantId"`
+
 	// Purpose contains the purpose of this LandscaperDeployment.
 	Purpose string `json:"purpose"`
 

--- a/pkg/apis/core/v1alpha1/types_instance.go
+++ b/pkg/apis/core/v1alpha1/types_instance.go
@@ -38,6 +38,12 @@ type Instance struct {
 
 // InstanceSpec contains the specification for an Instance.
 type InstanceSpec struct {
+	// TenantId is the unique identifier of the owning tenant.
+	TenantId string `json:"tenantId"`
+
+	// ID is the id of this instance
+	ID string `json:"id"`
+
 	// LandscaperConfiguration contains the configuration for the landscaper service deployment
 	LandscaperConfiguration LandscaperConfiguration `json:"landscaperConfiguration"`
 

--- a/pkg/apis/core/v1alpha1/types_landscaperdeployment.go
+++ b/pkg/apis/core/v1alpha1/types_landscaperdeployment.go
@@ -37,6 +37,9 @@ type LandscaperDeployment struct {
 
 // LandscaperDeploymentSpec contains the specification for a LandscaperDeployment.
 type LandscaperDeploymentSpec struct {
+	// TenantId is the unique identifier of the owning tenant.
+	TenantId string `json:"tenantId"`
+
 	// Purpose contains the purpose of this LandscaperDeployment.
 	Purpose string `json:"purpose"`
 

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -282,6 +282,8 @@ func Convert_core_InstanceList_To_v1alpha1_InstanceList(in *core.InstanceList, o
 }
 
 func autoConvert_v1alpha1_InstanceSpec_To_core_InstanceSpec(in *InstanceSpec, out *core.InstanceSpec, s conversion.Scope) error {
+	out.TenantId = in.TenantId
+	out.ID = in.ID
 	if err := Convert_v1alpha1_LandscaperConfiguration_To_core_LandscaperConfiguration(&in.LandscaperConfiguration, &out.LandscaperConfiguration, s); err != nil {
 		return err
 	}
@@ -297,6 +299,8 @@ func Convert_v1alpha1_InstanceSpec_To_core_InstanceSpec(in *InstanceSpec, out *c
 }
 
 func autoConvert_core_InstanceSpec_To_v1alpha1_InstanceSpec(in *core.InstanceSpec, out *InstanceSpec, s conversion.Scope) error {
+	out.TenantId = in.TenantId
+	out.ID = in.ID
 	if err := Convert_core_LandscaperConfiguration_To_v1alpha1_LandscaperConfiguration(&in.LandscaperConfiguration, &out.LandscaperConfiguration, s); err != nil {
 		return err
 	}
@@ -420,6 +424,7 @@ func Convert_core_LandscaperDeploymentList_To_v1alpha1_LandscaperDeploymentList(
 }
 
 func autoConvert_v1alpha1_LandscaperDeploymentSpec_To_core_LandscaperDeploymentSpec(in *LandscaperDeploymentSpec, out *core.LandscaperDeploymentSpec, s conversion.Scope) error {
+	out.TenantId = in.TenantId
 	out.Purpose = in.Purpose
 	if err := Convert_v1alpha1_LandscaperConfiguration_To_core_LandscaperConfiguration(&in.LandscaperConfiguration, &out.LandscaperConfiguration, s); err != nil {
 		return err
@@ -434,6 +439,7 @@ func Convert_v1alpha1_LandscaperDeploymentSpec_To_core_LandscaperDeploymentSpec(
 }
 
 func autoConvert_core_LandscaperDeploymentSpec_To_v1alpha1_LandscaperDeploymentSpec(in *core.LandscaperDeploymentSpec, out *LandscaperDeploymentSpec, s conversion.Scope) error {
+	out.TenantId = in.TenantId
 	out.Purpose = in.Purpose
 	if err := Convert_core_LandscaperConfiguration_To_v1alpha1_LandscaperConfiguration(&in.LandscaperConfiguration, &out.LandscaperConfiguration, s); err != nil {
 		return err

--- a/pkg/apis/openapi/openapi_generated.go
+++ b/pkg/apis/openapi/openapi_generated.go
@@ -460,6 +460,22 @@ func schema_pkg_apis_core_v1alpha1_InstanceSpec(ref common.ReferenceCallback) co
 				Description: "InstanceSpec contains the specification for an Instance.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"tenantId": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TenantId is the unique identifier of the owning tenant.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"id": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ID is the id of this instance",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"landscaperConfiguration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LandscaperConfiguration contains the configuration for the landscaper service deployment",
@@ -475,7 +491,7 @@ func schema_pkg_apis_core_v1alpha1_InstanceSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				Required: []string{"landscaperConfiguration", "serviceTargetConfigRef"},
+				Required: []string{"tenantId", "id", "landscaperConfiguration", "serviceTargetConfigRef"},
 			},
 		},
 		Dependencies: []string{
@@ -685,6 +701,14 @@ func schema_pkg_apis_core_v1alpha1_LandscaperDeploymentSpec(ref common.Reference
 				Description: "LandscaperDeploymentSpec contains the specification for a LandscaperDeployment.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"tenantId": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TenantId is the unique identifier of the owning tenant.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"purpose": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Purpose contains the purpose of this LandscaperDeployment.",
@@ -708,7 +732,7 @@ func schema_pkg_apis_core_v1alpha1_LandscaperDeploymentSpec(ref common.Reference
 						},
 					},
 				},
-				Required: []string{"purpose", "landscaperConfiguration"},
+				Required: []string{"tenantId", "purpose", "landscaperConfiguration"},
 			},
 		},
 		Dependencies: []string{

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -292,7 +292,7 @@ func (c *Controller) mutateInstallation(ctx context.Context, log logr.Logger, in
 			},
 		},
 		ImportDataMappings: map[string]lsv1alpha1.AnyJSON{
-			lsinstallation.HostingClusterNamespaceImportName: utils.StringToAnyJSON(fmt.Sprintf("%s-%s", instance.GetNamespace(), instance.GetName())),
+			lsinstallation.HostingClusterNamespaceImportName: utils.StringToAnyJSON(fmt.Sprintf("%s-%s", instance.Spec.TenantId, instance.Spec.ID)),
 			lsinstallation.DeleteHostingClusterImportName:    utils.BoolToAnyJSON(true),
 			lsinstallation.VirtualClusterNamespaceImportName: utils.StringToAnyJSON(lsinstallation.VirtualClusterNamespace),
 			lsinstallation.ProviderTypeImportName:            utils.StringToAnyJSON(config.Spec.ProviderType),

--- a/pkg/controllers/instances/reconcile_test.go
+++ b/pkg/controllers/instances/reconcile_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(installation.Spec.ComponentDescriptor.Reference.ComponentName).To(Equal(op.Config().LandscaperServiceComponent.Name))
 		Expect(installation.Spec.ImportDataMappings[lsinstallation.ProviderTypeImportName]).To(Equal(utils.StringToAnyJSON(config.Spec.ProviderType)))
 		Expect(installation.Spec.ImportDataMappings[lsinstallation.VirtualClusterNamespaceImportName]).To(Equal(utils.StringToAnyJSON(lsinstallation.VirtualClusterNamespace)))
-		Expect(installation.Spec.ImportDataMappings[lsinstallation.HostingClusterNamespaceImportName]).To(Equal(utils.StringToAnyJSON(fmt.Sprintf("%s-%s", instance.Namespace, instance.Name))))
+		Expect(installation.Spec.ImportDataMappings[lsinstallation.HostingClusterNamespaceImportName]).To(Equal(utils.StringToAnyJSON("12345-abcdef")))
 
 		landscaperConfigRaw := installation.Spec.ImportDataMappings[lsinstallation.LandscaperConfigImportName]
 		Expect(landscaperConfigRaw).ToNot(BeNil())

--- a/pkg/controllers/instances/testdata/reconcile/test1/instance.yaml
+++ b/pkg/controllers/instances/testdata/reconcile/test1/instance.yaml
@@ -8,6 +8,8 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
+  id: "abcdef"
   purpose: "test"
   landscaperConfiguration:
     deployers:

--- a/pkg/controllers/instances/testdata/reconcile/test2/instance.yaml
+++ b/pkg/controllers/instances/testdata/reconcile/test2/instance.yaml
@@ -8,6 +8,8 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
+  id: "abcdef"
   purpose: "test"
   landscaperConfiguration:
     deployers:

--- a/pkg/controllers/instances/testdata/reconcile/test3/instance.yaml
+++ b/pkg/controllers/instances/testdata/reconcile/test3/instance.yaml
@@ -8,6 +8,8 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
+  id: "abcdef"
   purpose: "test"
   landscaperConfiguration:
     deployers:

--- a/pkg/controllers/landscaperdeployments/reconcile.go
+++ b/pkg/controllers/landscaperdeployments/reconcile.go
@@ -6,6 +6,8 @@ package landscaperdeployments
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -95,6 +97,13 @@ func (c *Controller) mutateInstance(ctx context.Context, log logr.Logger, deploy
 		instance.Spec.ServiceTargetConfigRef.Namespace = serviceTargetConf.GetNamespace()
 	}
 
+	if len(instance.Spec.ID) == 0 {
+		h := sha1.New()
+		id := h.Sum([]byte(instance.Name))
+		instance.Spec.ID = hex.EncodeToString(id[:4])
+	}
+
+	instance.Spec.TenantId = deployment.Spec.TenantId
 	instance.Spec.LandscaperConfiguration = deployment.Spec.LandscaperConfiguration
 	c.Operation.Scheme().Default(instance)
 

--- a/pkg/controllers/landscaperdeployments/reconcile.go
+++ b/pkg/controllers/landscaperdeployments/reconcile.go
@@ -97,11 +97,13 @@ func (c *Controller) mutateInstance(ctx context.Context, log logr.Logger, deploy
 		instance.Spec.ServiceTargetConfigRef.Namespace = serviceTargetConf.GetNamespace()
 	}
 
-	if len(instance.Spec.ID) == 0 {
-		h := sha1.New()
-		id := h.Sum([]byte(instance.Name))
-		instance.Spec.ID = hex.EncodeToString(id[:4])
-	}
+	// The instance has a generated name and therefore may be not set yet.
+	// The hash is therefore calculated with the name of the deployment.
+	// Since the name of the instance is derived from the deployment name, which is unique in a namespace,
+	// the hash value is also unique.
+	h := sha1.New()
+	id := h.Sum([]byte(deployment.Name))
+	instance.Spec.ID = hex.EncodeToString(id[:4])
 
 	instance.Spec.TenantId = deployment.Spec.TenantId
 	instance.Spec.LandscaperConfiguration = deployment.Spec.LandscaperConfiguration

--- a/pkg/controllers/landscaperdeployments/reconcile_test.go
+++ b/pkg/controllers/landscaperdeployments/reconcile_test.go
@@ -220,6 +220,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(instance.Spec.ServiceTargetConfigRef.Name).To(Equal("config2"))
 		Expect(instance.Spec.LandscaperConfiguration).To(Equal(deployment.Spec.LandscaperConfiguration))
+		Expect(instance.Spec.TenantId).To(Equal(deployment.Spec.TenantId))
+		Expect(instance.Spec.ID).To(MatchRegexp("[a-f0-9]+"))
 
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(config), config)).To(Succeed())
 		Expect(config.Status.InstanceRefs).To(HaveLen(1))
@@ -256,6 +258,7 @@ var _ = Describe("Reconcile", func() {
 		instance := &lssv1alpha1.Instance{}
 		err = testenv.Client.Get(ctx, types.NamespacedName{Name: deployment.Status.InstanceRef.Name, Namespace: deployment.Status.InstanceRef.Namespace}, instance)
 		Expect(err).ToNot(HaveOccurred())
+		uid := instance.Spec.ID
 
 		deployment.Spec.LandscaperConfiguration.Deployers = []string{
 			"foo",
@@ -265,5 +268,6 @@ var _ = Describe("Reconcile", func() {
 		err = testenv.Client.Get(ctx, types.NamespacedName{Name: deployment.Status.InstanceRef.Name, Namespace: deployment.Status.InstanceRef.Namespace}, instance)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(instance.Spec.LandscaperConfiguration).To(Equal(deployment.Spec.LandscaperConfiguration))
+		Expect(instance.Spec.ID).To(Equal(uid))
 	})
 })

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test1/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test1/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
   purpose: "test"
   landscaperConfiguration:
     deployers:

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test2/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test2/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
   purpose: "test"
   region: "eu"
   landscaperConfiguration:

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test3/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test3/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
   purpose: "test"
   region: "eu"
   landscaperConfiguration:

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test4/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test4/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   name: "test"
   namespace: {{ .Namespace }}
 spec:
+  tenantId: "12345"
   purpose: "test"
   region: "eu"
   landscaperConfiguration:

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
@@ -33,6 +33,9 @@ spec:
           spec:
             description: Spec contains the specification for the Instance.
             properties:
+              id:
+                description: ID is the id of this instance
+                type: string
               landscaperConfiguration:
                 description: LandscaperConfiguration contains the configuration for
                   the landscaper service deployment
@@ -59,7 +62,12 @@ spec:
                 required:
                 - name
                 type: object
+              tenantId:
+                description: TenantId is the unique identifier of the owning tenant.
+                type: string
             required:
+            - tenantId
+            - id
             - landscaperConfiguration
             - serviceTargetConfigRef
             type: object

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_landscaperdeployments.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_landscaperdeployments.yaml
@@ -49,7 +49,11 @@ spec:
                 description: Region selects the region this LandscaperDeployment should
                   be installed on.
                 type: string
+              tenantId:
+                description: TenantId is the unique identifier of the owning tenant.
+                type: string
             required:
+            - tenantId
             - purpose
             - landscaperConfiguration
             type: object


### PR DESCRIPTION
**What this PR does / why we need it**:

Whith this PR the landscaper deployment and the instance have the tenant id added to the resource specification.
The instance specification has an id field added which contains the hashed name of the instance.

The hosting cluster namespace for the laas installation is now build by "tenantID-instanceID".
This was changed in order to prevent extra large namespace and landscaper environment names (and potential maximum length excess). These names now have a fixed length regardless of the name of the landscaper deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
none
```
