### PR TITLE
use guuid for the instance id

### DIFF
--- a/pkg/controllers/landscaperdeployments/reconcile.go
+++ b/pkg/controllers/landscaperdeployments/reconcile.go
@@ -6,18 +6,18 @@ package landscaperdeployments
 
 import (
 	"context"
-	"crypto/sha1"
-	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
@@ -97,13 +97,22 @@ func (c *Controller) mutateInstance(ctx context.Context, log logr.Logger, deploy
 		instance.Spec.ServiceTargetConfigRef.Namespace = serviceTargetConf.GetNamespace()
 	}
 
-	// The instance has a generated name and therefore may be not set yet.
-	// The hash is therefore calculated with the name of the deployment.
-	// Since the name of the instance is derived from the deployment name, which is unique in a namespace,
-	// the hash value is also unique.
-	h := sha1.New()
-	id := h.Sum([]byte(deployment.Name))
-	instance.Spec.ID = hex.EncodeToString(id[:4])
+	if len(instance.Spec.ID) == 0 {
+		instanceList := &lssv1alpha1.InstanceList{}
+		if err := c.Client().List(ctx, instanceList, &client.ListOptions{Namespace: deployment.Namespace}); err != nil {
+			return fmt.Errorf("unable to list instances in namespace %s: %w", deployment.Namespace, err)
+		}
+
+		existingIds := sets.NewString()
+		for _, i := range instanceList.Items {
+			existingIds.Insert(i.Spec.ID)
+		}
+
+		var id string
+		for id = c.NewUniqueID(); existingIds.Has(id); id = c.NewUniqueID() {
+		}
+		instance.Spec.ID = id
+	}
 
 	instance.Spec.TenantId = deployment.Spec.TenantId
 	instance.Spec.LandscaperConfiguration = deployment.Spec.LandscaperConfiguration

--- a/pkg/controllers/landscaperdeployments/reconcile.go
+++ b/pkg/controllers/landscaperdeployments/reconcile.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/util/sets"
-
 	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/deployment.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: LandscaperDeployment
+metadata:
+  name: "test"
+  namespace: {{ .Namespace }}
+spec:
+  tenantId: "12345"
+  purpose: "test"
+  region: "eu"
+  landscaperConfiguration:
+    deployers:
+      - helm
+      - manifest
+      - container

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/instance.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/instance.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: Instance
+metadata:
+  name: "existing"
+  namespace: {{ .Namespace }}
+spec:
+  tenantId: "12345"
+  id: "aabbccdd"
+  landscaperConfiguration:
+    deployers:
+      - helm
+      - manifest
+      - container
+  serviceTargetConfigRef:
+    name: "config1"
+    namespace: {{ .Namespace }}

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/servicetargetconf.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test5/servicetargetconf.yaml
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: target
+  namespace: {{ .Namespace }}
+type: Opaque
+stringData:
+  kubeconfig: |
+    dummy
+---
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: ServiceTargetConfig
+
+metadata:
+  name: config1
+  namespace: {{ .Namespace }}
+  labels:
+    config.landscaper-service.gardener.cloud/visible: "true"
+    config.landscaper-service.gardener.cloud/region: eu
+
+spec:
+  providerType: gcp
+  priority: 10
+
+  secretRef:
+    name: target
+    namespace: {{ .Namespace }}
+    key: kubeconfig
+---
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: ServiceTargetConfig
+
+metadata:
+  name: config2
+  namespace: {{ .Namespace }}
+  labels:
+    config.landscaper-service.gardener.cloud/visible: "true"
+    config.landscaper-service.gardener.cloud/region: eu
+
+spec:
+  providerType: gcp
+  priority: 20
+
+  secretRef:
+    name: target
+    namespace: {{ .Namespace }}
+    key: kubeconfig
+---
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: ServiceTargetConfig
+
+metadata:
+  name: config3
+  namespace: {{ .Namespace }}
+  labels:
+    config.landscaper-service.gardener.cloud/visible: "true"
+    config.landscaper-service.gardener.cloud/region: us
+
+spec:
+  providerType: gcp
+  priority: 30
+
+  secretRef:
+    name: target
+    namespace: {{ .Namespace }}
+    key: kubeconfig
+---
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: ServiceTargetConfig
+
+metadata:
+  name: configt4
+  namespace: {{ .Namespace }}
+  labels:
+    config.landscaper-service.gardener.cloud/visible: "false"
+    config.landscaper-service.gardener.cloud/region: eu
+
+spec:
+  providerType: gcp
+  priority: 30
+
+  secretRef:
+    name: target
+    namespace: {{ .Namespace }}
+    key: kubeconfig

--- a/vendor/github.com/google/uuid/null.go
+++ b/vendor/github.com/google/uuid/null.go
@@ -1,0 +1,118 @@
+// Copyright 2021 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uuid
+
+import (
+	"bytes"
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+var jsonNull = []byte("null")
+
+// NullUUID represents a UUID that may be null.
+// NullUUID implements the SQL driver.Scanner interface so
+// it can be used as a scan destination:
+//
+//  var u uuid.NullUUID
+//  err := db.QueryRow("SELECT name FROM foo WHERE id=?", id).Scan(&u)
+//  ...
+//  if u.Valid {
+//     // use u.UUID
+//  } else {
+//     // NULL value
+//  }
+//
+type NullUUID struct {
+	UUID  UUID
+	Valid bool // Valid is true if UUID is not NULL
+}
+
+// Scan implements the SQL driver.Scanner interface.
+func (nu *NullUUID) Scan(value interface{}) error {
+	if value == nil {
+		nu.UUID, nu.Valid = Nil, false
+		return nil
+	}
+
+	err := nu.UUID.Scan(value)
+	if err != nil {
+		nu.Valid = false
+		return err
+	}
+
+	nu.Valid = true
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (nu NullUUID) Value() (driver.Value, error) {
+	if !nu.Valid {
+		return nil, nil
+	}
+	// Delegate to UUID Value function
+	return nu.UUID.Value()
+}
+
+// MarshalBinary implements encoding.BinaryMarshaler.
+func (nu NullUUID) MarshalBinary() ([]byte, error) {
+	if nu.Valid {
+		return nu.UUID[:], nil
+	}
+
+	return []byte(nil), nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler.
+func (nu *NullUUID) UnmarshalBinary(data []byte) error {
+	if len(data) != 16 {
+		return fmt.Errorf("invalid UUID (got %d bytes)", len(data))
+	}
+	copy(nu.UUID[:], data)
+	nu.Valid = true
+	return nil
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (nu NullUUID) MarshalText() ([]byte, error) {
+	if nu.Valid {
+		return nu.UUID.MarshalText()
+	}
+
+	return jsonNull, nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (nu *NullUUID) UnmarshalText(data []byte) error {
+	id, err := ParseBytes(data)
+	if err != nil {
+		nu.Valid = false
+		return err
+	}
+	nu.UUID = id
+	nu.Valid = true
+	return nil
+}
+
+// MarshalJSON implements json.Marshaler.
+func (nu NullUUID) MarshalJSON() ([]byte, error) {
+	if nu.Valid {
+		return json.Marshal(nu.UUID)
+	}
+
+	return jsonNull, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (nu *NullUUID) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, jsonNull) {
+		*nu = NullUUID{}
+		return nil // valid null UUID
+	}
+	err := json.Unmarshal(data, &nu.UUID)
+	nu.Valid = err == nil
+	return err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Using the fixed first four bytes of hashed value of the deployment name is not unique when the deployment names start with the same prefix.
Therefore a fixed 4 byte guuid is used instead.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
