### PR TITLE
always use dev version for integration test

### DIFF
--- a/hack/get-version.sh
+++ b/hack/get-version.sh
@@ -6,12 +6,6 @@
 
 set -e
 
-if [ -n "$TM_GIT_REF" ] ; then
-  # running e2e test in a release job, use TM_GIT_REF as image tag (is set to git release tag name)
-  echo "$TM_GIT_REF"
-  exit 0
-fi
-
 if [ -n "$EFFECTIVE_VERSION" ] ; then
   # running in the pipeline use the provided EFFECTIVE_VERSION
   echo "$EFFECTIVE_VERSION"
@@ -22,12 +16,6 @@ SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(cat "${SOURCE_PATH}/VERSION")"
 
 pushd ${SOURCE_PATH} > /dev/null 2>&1
-
-if [ -n "$TM_GIT_SHA" ] ; then
-  # running e2e test for a PR, calculate image tag by concatenating VERSION and commit sha.
-  echo "$VERSION-$TM_GIT_SHA"
-  exit 0
-fi
 
 if [[ "$VERSION" = *-dev ]] ; then
   VERSION="$VERSION-$(git rev-parse HEAD)"

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
 #
@@ -13,8 +13,6 @@ then
     apk add --no-cache --no-progress git
 fi
 
-
-
 PROJECT_ROOT="$(dirname $0)/.."
 TARGET_CLUSTER="laas-integration-test"
 TARGET_CLUSTER_PROVIDER="gcp"
@@ -22,11 +20,8 @@ LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
 REPO_AUTH_URL="https://eu.gcr.io"
 REPO_CTX_BASE_URL="eu.gcr.io/sap-se-gcr-k8s-private"
 
-LAAS_VERSION="$(cat "${PROJECT_ROOT}/VERSION")"
-pushd "${PROJECT_ROOT}" > /dev/null 2>&1
-LAAS_VERSION="$VERSION-$(git rev-parse HEAD)"
-popd > /dev/null 2>&1
-
+unset EFFECTIVE_VERSION
+LAAS_VERSION="$(${PROJECT_ROOT}/hack/get-version.sh)"
 
 export PROJECT_ROOT
 export TARGET_CLUSTER

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
 #
@@ -13,13 +13,20 @@ then
     apk add --no-cache --no-progress git
 fi
 
+
+
 PROJECT_ROOT="$(dirname $0)/.."
 TARGET_CLUSTER="laas-integration-test"
 TARGET_CLUSTER_PROVIDER="gcp"
-LAAS_VERSION="$("${SOURCE_PATH}"/hack/get-version.sh)"
 LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
 REPO_AUTH_URL="https://eu.gcr.io"
 REPO_CTX_BASE_URL="eu.gcr.io/sap-se-gcr-k8s-private"
+
+LAAS_VERSION="$(cat "${PROJECT_ROOT}/VERSION")"
+pushd "${PROJECT_ROOT}" > /dev/null 2>&1
+LAAS_VERSION="$VERSION-$(git rev-parse HEAD)"
+popd > /dev/null 2>&1
+
 
 export PROJECT_ROOT
 export TARGET_CLUSTER


### PR DESCRIPTION
**What this PR does / why we need it**:

For release jobs the effective version will be set to the next release version, e.g. "v0.1.0".
The integration test tries to access the component descriptor with that said version.
However, the version will only be uploaded to the component registry after the integration has run.

Therefore the integration test uses the last dev version uploaded by the head update job.
The content of this dev version is identical of the version to be released.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
