### PR TITLE
change instance short name to 'instc'

### DIFF
--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_instance.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_instance.go
@@ -92,7 +92,7 @@ var InstanceDefinition = lsschema.CustomResourceDefinition{
 		Plural:   "instances",
 		Singular: "instance",
 		ShortNames: []string{
-			"inst",
+			"instc",
 		},
 		Kind: "Instance",
 	},

--- a/pkg/apis/core/v1alpha1/types_instance.go
+++ b/pkg/apis/core/v1alpha1/types_instance.go
@@ -92,7 +92,7 @@ var InstanceDefinition = lsschema.CustomResourceDefinition{
 		Plural:   "instances",
 		Singular: "instance",
 		ShortNames: []string{
-			"inst",
+			"instc",
 		},
 		Kind: "Instance",
 	},

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
@@ -9,7 +9,7 @@ spec:
     kind: Instance
     plural: instances
     shortNames:
-    - inst
+    - instc
     singular: instance
   scope: Namespaced
   versions:


### PR DESCRIPTION
**What this PR does / why we need it**:
The short name "inst" for the instance crd is colliding with the short name of the landscaper installation crd.
Change short name to "instc"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
change instance crd short name to "instc"
```
