### PR TITLE
add documentation for deployment tenantId and instance id

### DIFF
--- a/docs/gettingstarted/create-landscaper-deployment.md
+++ b/docs/gettingstarted/create-landscaper-deployment.md
@@ -16,6 +16,7 @@ kubectl create namespace laas-user
 ```
 
 In the next step, the LandscaperDeployment resource is created. The field `spec.landscaperConfiguration.deployers` has to contain the list of active deployers.
+The field `spec.tenantId` has to contain globally unique tenant id.
 
 ```yaml
 apiVersion: landscaper-service.gardener.cloud/v1alpha1
@@ -23,6 +24,7 @@ kind: LandscaperDeployment
 metadata:
   name: test
 spec:
+  tenantId: "tenant-1"
   purpose: "test"
   landscaperConfiguration:
     deployers:

--- a/docs/gettingstarted/create-landscaper-deployment.md
+++ b/docs/gettingstarted/create-landscaper-deployment.md
@@ -16,7 +16,7 @@ kubectl create namespace laas-user
 ```
 
 In the next step, the LandscaperDeployment resource is created. The field `spec.landscaperConfiguration.deployers` has to contain the list of active deployers.
-The field `spec.tenantId` has to contain globally unique tenant id.
+The field `spec.tenantId` has to contain a globally unique tenant id.
 
 ```yaml
 apiVersion: landscaper-service.gardener.cloud/v1alpha1

--- a/docs/usage/Instances.md
+++ b/docs/usage/Instances.md
@@ -19,6 +19,8 @@ metadata:
   name: test
   namespace: my-namespace
 spec:
+  tenantId: "tenant-1"
+  id: "1234"
   landscaperConfiguration:
     deployers:
       - helm
@@ -48,6 +50,14 @@ status:
   clusterEndpoint: "10.0.0.1:1234"
   clusterKubeconfig: "a3ViZWNvbmZpZyBjb250ZW50 ..."
 ```
+
+## TenantId
+
+The `spec.tenantId` field contains the globally unique identifier of the owning tenant.
+
+## Id
+
+The `spec.id` field contains the id of the instance unique among all instances within the same namespace.
 
 ## Landscaper Configuration
 

--- a/docs/usage/LandscaperDeployments.md
+++ b/docs/usage/LandscaperDeployments.md
@@ -19,6 +19,7 @@ metadata:
   name: test
   namespace: my-namespace
 spec:
+  tenantId: "tenant-1"
   purpose: "test"
   region: "eu-west-1"
   landscaperConfiguration:
@@ -32,6 +33,10 @@ status:
     name: test
     namespace: my-namespace
 ```
+
+## TenantId
+
+The `spec.tenantId` field has to contain the globally unique identifier of the owning tenant.
 
 ## Purpose
 


### PR DESCRIPTION
**What this PR does / why we need it**:

add documentation for landscaper deployment tenantId and instance id.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
