### PR TITLE
use correct variables for deletion status

### DIFF
--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -33,22 +33,22 @@ func (c *Controller) handleDelete(ctx context.Context, log logr.Logger, instance
 	)
 
 	if instance.Status.InstallationRef != nil && !instance.Status.InstallationRef.IsEmpty() {
-		if targetDeleted, err = c.ensureDeleteInstallationForInstance(ctx, log, instance); err != nil {
+		if installationDeleted, err = c.ensureDeleteInstallationForInstance(ctx, log, instance); err != nil {
 			return lsserrors.NewWrappedError(err, curOp, "DeleteInstallation", err.Error())
 		}
 	}
 
-	if !targetDeleted {
+	if !installationDeleted {
 		return nil
 	}
 
 	if instance.Status.TargetRef != nil && !instance.Status.TargetRef.IsEmpty() {
-		if installationDeleted, err = c.ensureDeleteTargetForInstance(ctx, log, instance); err != nil {
+		if targetDeleted, err = c.ensureDeleteTargetForInstance(ctx, log, instance); err != nil {
 			return lsserrors.NewWrappedError(err, curOp, "DeleteTarget", err.Error())
 		}
 	}
 
-	if !installationDeleted {
+	if !targetDeleted {
 		return nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Use correct variables for the deletion status in the delete reconciler.
This is only a cosmetic fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
