### PR TITLE
change base image to gcr.io/distroless/static-debian11:nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 #### BASE ####
-FROM alpine:3.16.0 AS base
-
-RUN apk add --no-cache ca-certificates
+FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 #### Landscaper Service controller ####
 FROM base as landscaper-service-controller


### PR DESCRIPTION
**What this PR does / why we need it**:

Change base image to gcr.io/distroless/static-debian11:nonroot
This should reduce the vulnerability scanner noise, since only the absolutely necessary parts are stored in the image. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change base image to gcr.io/distroless/static-debian11:nonroot
```
