### PR TITLE
update integration test

### DIFF
--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -33,10 +33,11 @@ hosting_cluster_kubeconfig = factory.kubernetes(hosting_cluster)
 print(f"Getting credentials for {repo_ctx_base_url}")
 cr_conf = model.container_registry.find_config(repo_ctx_base_url, oa.Privileges.READONLY)
 
-with utils.TempFileAuto(prefix="test_cluster_kubeconfig_") as test_cluster_kubeconfig_temp_file,
-     utils.TempFileAuto(prefix="hosting_cluster_kubeconfig_") as hosting_cluster_kubeconfig_temp_file,
-     utils.TempFileAuto(prefix="registry_auth_", suffix=".json") as registry_temp_file:
-
+with (
+    utils.TempFileAuto(prefix="test_cluster_kubeconfig_") as test_cluster_kubeconfig_temp_file,
+    utils.TempFileAuto(prefix="hosting_cluster_kubeconfig_") as hosting_cluster_kubeconfig_temp_file,
+    utils.TempFileAuto(prefix="registry_auth_", suffix=".json") as registry_temp_file
+):
     test_cluster_kubeconfig_temp_file.write(yaml.safe_dump(test_cluster_kubeconfig.kubeconfig()))
     test_cluster_kubeconfig_path = test_cluster_kubeconfig_temp_file.switch()
 

--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -16,7 +16,8 @@ from util import ctx
 from subprocess import run
 
 project_root = os.environ["PROJECT_ROOT"]
-target_cluster = os.environ["TARGET_CLUSTER"]
+test_cluster = os.environ["TEST_CLUSTER"]
+hosting_cluster = os.environ["HOSTING_CLUSTER"]
 target_cluster_provider = os.environ["TARGET_CLUSTER_PROVIDER"]
 laas_version = os.environ["LAAS_VERSION"]
 laas_repository = os.environ["LAAS_REPOSITORY"]
@@ -24,15 +25,23 @@ repo_ctx_base_url = os.environ["REPO_CTX_BASE_URL"]
 repo_auth_url = os.environ["REPO_AUTH_URL"]
 
 factory = ctx().cfg_factory()
-print(f"Getting kubeconfig for {target_cluster}")
-landscape_kubeconfig = factory.kubernetes(target_cluster)
+print(f"Getting kubeconfig for {test_cluster}")
+test_cluster_kubeconfig = factory.kubernetes(test_cluster)
+print(f"Getting kubeconfig for {hosting_cluster}")
+hosting_cluster_kubeconfig = factory.kubernetes(hosting_cluster)
 
 print(f"Getting credentials for {repo_ctx_base_url}")
 cr_conf = model.container_registry.find_config(repo_ctx_base_url, oa.Privileges.READONLY)
 
-with utils.TempFileAuto(prefix="landscape_kubeconfig_") as kubeconfig_temp_file, utils.TempFileAuto(prefix="registry_auth_", suffix=".json") as registry_temp_file:
-    kubeconfig_temp_file.write(yaml.safe_dump(landscape_kubeconfig.kubeconfig()))
-    landscape_kubeconfig_path = kubeconfig_temp_file.switch()
+with utils.TempFileAuto(prefix="test_cluster_kubeconfig_") as test_cluster_kubeconfig_temp_file,
+     utils.TempFileAuto(prefix="hosting_cluster_kubeconfig_") as hosting_cluster_kubeconfig_temp_file,
+     utils.TempFileAuto(prefix="registry_auth_", suffix=".json") as registry_temp_file:
+
+    test_cluster_kubeconfig_temp_file.write(yaml.safe_dump(test_cluster_kubeconfig.kubeconfig()))
+    test_cluster_kubeconfig_path = test_cluster_kubeconfig_temp_file.switch()
+
+    hosting_cluster_kubeconfig_temp_file.write(yaml.safe_dump(hosting_cluster_kubeconfig.kubeconfig()))
+    hosting_cluster_kubeconfig_path = hosting_cluster_kubeconfig_temp_file.switch()
 
     auth = utils.base64_encode_to_string(cr_conf.credentials().username() + ":" + cr_conf.credentials().passwd())
     auths = {
@@ -47,7 +56,8 @@ with utils.TempFileAuto(prefix="landscape_kubeconfig_") as kubeconfig_temp_file,
     registry_secrets_path = registry_temp_file.switch()
 
     command = ["go", "run", "./pkg/main.go",
-                "--kubeconfig", landscape_kubeconfig_path,
+                "--kubeconfig", test_cluster_kubeconfig_path,
+                "--hosting-kubeconfig", hosting_cluster_kubeconfig_path,
                 "--provider-type", target_cluster_provider,
                 "--laas-version", laas_version,
                 "--laas-repository", laas_repository,

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -24,6 +24,7 @@ REPO_CTX_BASE_URL="eu.gcr.io/sap-se-gcr-k8s-private"
 
 export PROJECT_ROOT
 export TEST_CLUSTER
+export HOSTING_CLUSTER
 export TARGET_CLUSTER_PROVIDER
 export LAAS_VERSION
 export LAAS_REPOSITORY

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -14,7 +14,8 @@ then
 fi
 
 PROJECT_ROOT="$(dirname $0)/.."
-TARGET_CLUSTER="laas-integration-test"
+TEST_CLUSTER="laas-integration-test"
+HOSTING_CLUSTER="laas-integration-test-target"
 TARGET_CLUSTER_PROVIDER="gcp"
 LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
 LAAS_VERSION="$(${PROJECT_ROOT}/hack/get-version.sh)"

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -23,7 +23,7 @@ REPO_AUTH_URL="https://eu.gcr.io"
 REPO_CTX_BASE_URL="eu.gcr.io/sap-se-gcr-k8s-private"
 
 export PROJECT_ROOT
-export TARGET_CLUSTER
+export TEST_CLUSTER
 export TARGET_CLUSTER_PROVIDER
 export LAAS_VERSION
 export LAAS_REPOSITORY

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -40,6 +40,7 @@ var (
 		new(tests.UpdateDeploymentRunner),
 		new(tests.VerifyDeploymentRunner),
 		new(tests.ManifestDeployerTestRunner),
+		new(tests.HelmDeployerTestRunner),
 		new(tests.DeleteDeploymentRunner),
 		new(tests.VerifyDeleteRunner),
 		new(tests.UninstallLAASTestRunner),

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -9,9 +9,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"text/template"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/controller-utils/pkg/logger"
@@ -161,7 +162,7 @@ func runTestSuite(ctx context.Context, log logr.Logger, clusterClients *test.Clu
 
 	for _, runner := range integrationTests {
 		testsNotRun = testsNotRun[1:]
-		log.Info("running test", "name", runner.Name())
+		log.Info("********** running test", "name", runner.Name())
 		runner.Init(ctx, log, config, clusterClients, clusterTarget, testObjects)
 		if err := runner.Run(); err != nil {
 			return logTestSummary(log, succeededTests, testsNotRun, err, runner)
@@ -174,8 +175,8 @@ func runTestSuite(ctx context.Context, log logr.Logger, clusterClients *test.Clu
 
 func logTestSummary(log logr.Logger, succeededTests, testsNotRun []test.TestRunner, err error, failedTest test.TestRunner) error {
 	log.Info("==========  Test summary ==========")
-	log.Info("successful tests", "tests", fmt.Sprintf("%v", succeededTests))
-	log.Info("tests not run", "tests", fmt.Sprintf("%v", testsNotRun))
+	log.Info("successful tests", "tests", fmt.Sprintf("%v", succeededTests), "total", fmt.Sprintf("%d/%d", len(succeededTests), len(integrationTests)))
+	log.Info("tests not run", "tests", fmt.Sprintf("%v", testsNotRun), "total", fmt.Sprintf("%d/%d", len(testsNotRun), len(integrationTests)))
 	if err != nil {
 		log.Error(err, "error while running test", "name", failedTest.Name())
 	}

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -152,7 +152,7 @@ func runTestSuite(ctx context.Context, log logr.Logger, clusterClients *test.Clu
 	}
 
 	succeededTests := make([]test.TestRunner, 0, len(integrationTests))
-	testsNotRun := make([]test.TestRunner, len(integrationTests), len(integrationTests))
+	testsNotRun := make([]test.TestRunner, len(integrationTests))
 	copy(testsNotRun, integrationTests)
 
 	log.Info("following tests will be run")

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -21,7 +21,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
@@ -39,6 +38,7 @@ var (
 		new(tests.VerifyDeploymentRunner),
 		new(tests.UpdateDeploymentRunner),
 		new(tests.VerifyDeploymentRunner),
+		new(tests.ManifestDeployerTestRunner),
 		new(tests.DeleteDeploymentRunner),
 		new(tests.VerifyDeleteRunner),
 		new(tests.UninstallLAASTestRunner),
@@ -87,25 +87,18 @@ func run() error {
 		"Provider Type", config.ProviderType,
 	)
 
-	cfg, err := clientcmd.BuildConfigFromFlags("", config.Kubeconfig)
-	if err != nil {
-		return err
-	}
-
-	kclient, err := client.New(cfg, client.Options{
-		Scheme: test.Scheme(),
-	})
+	clusterClients, err := test.NewClusterClients(config)
 	if err != nil {
 		return err
 	}
 
 	log.Info("========== Uninstalling Landscaper ==========")
-	if err := uninstallLandscaper(ctx, log, kclient, config); err != nil {
+	if err := uninstallLandscaper(ctx, log, clusterClients.TestCluster, config); err != nil {
 		return err
 	}
 
 	log.Info("========== Cleaning up before test ==========")
-	if err := cleanupResources(ctx, log, kclient, config); err != nil {
+	if err := cleanupResources(ctx, log, clusterClients.TestCluster, clusterClients.HostingCluster, config); err != nil {
 		return err
 	}
 
@@ -121,7 +114,7 @@ func run() error {
 		},
 	}
 
-	if err := kclient.Create(ctx, namespace); err != nil {
+	if err := clusterClients.TestCluster.Create(ctx, namespace); err != nil {
 		return fmt.Errorf("failed to create laas namespace: %w", err)
 	}
 
@@ -131,24 +124,24 @@ func run() error {
 		},
 	}
 
-	if err := kclient.Create(ctx, namespace); err != nil {
+	if err := clusterClients.TestCluster.Create(ctx, namespace); err != nil {
 		return fmt.Errorf("failed to create test namespace: %w", err)
 	}
 
-	target, err := util.BuildKubernetesClusterTarget(ctx, kclient, config.Kubeconfig, config.LaasNamespace)
+	clusterTargets, err := test.NewClusterTargets(ctx, clusterClients.TestCluster, config)
 	if err != nil {
-		return fmt.Errorf("cannot build target: %w", err)
+		return err
 	}
 
-	if err := util.BuildLandscaperContext(ctx, kclient, config.RegistryPullSecrets, "laas", config.LaasNamespace); err != nil {
+	if err := util.BuildLandscaperContext(ctx, clusterClients.TestCluster, config.RegistryPullSecrets, "laas", config.LaasNamespace); err != nil {
 		return fmt.Errorf("cannot build landscaper context: %w", err)
 	}
 
-	return runTestSuite(ctx, log, kclient, config, target)
+	return runTestSuite(ctx, log, clusterClients, clusterTargets, config)
 }
 
 // runTestSuite runs the tests defined in integrationTests
-func runTestSuite(ctx context.Context, log logr.Logger, kclient client.Client, config *test.TestConfig, target *lsv1alpha1.Target) error {
+func runTestSuite(ctx context.Context, log logr.Logger, clusterClients *test.ClusterClients, clusterTarget *test.ClusterTargets, config *test.TestConfig) error {
 	log.Info("========== Running test suite ==========")
 	testObjects := &test.SharedTestObjects{
 		Installations:            make(map[string]*lsv1alpha1.Installation),
@@ -169,7 +162,7 @@ func runTestSuite(ctx context.Context, log logr.Logger, kclient client.Client, c
 	for _, runner := range integrationTests {
 		testsNotRun = testsNotRun[1:]
 		log.Info("running test", "name", runner.Name())
-		runner.Init(ctx, log, kclient, config, target, testObjects)
+		runner.Init(ctx, log, config, clusterClients, clusterTarget, testObjects)
 		if err := runner.Run(); err != nil {
 			return logTestSummary(log, succeededTests, testsNotRun, err, runner)
 		}
@@ -199,9 +192,7 @@ func uninstallLandscaper(ctx context.Context, log logr.Logger, kclient client.Cl
 
 	if err := kclient.Get(ctx, types.NamespacedName{Name: config.LandscaperNamespace}, landscaperNamespace); err != nil {
 		if apierrors.IsNotFound(err) {
-			if err := kclient.Create(ctx, landscaperNamespace); err != nil {
-				return fmt.Errorf("failed to create landscaper namespace %s: %w", config.LandscaperNamespace, err)
-			}
+			return nil
 		} else {
 			return fmt.Errorf("failed to get landscaper namespace %s: %w", config.LandscaperNamespace, err)
 		}
@@ -209,7 +200,7 @@ func uninstallLandscaper(ctx context.Context, log logr.Logger, kclient client.Cl
 
 	uninstallArgs := []string{
 		"--kubeconfig",
-		config.Kubeconfig,
+		config.TestClusterKubeconfig,
 		"--namespace",
 		config.LandscaperNamespace,
 		"--delete-namespace",
@@ -226,7 +217,7 @@ func uninstallLandscaper(ctx context.Context, log logr.Logger, kclient client.Cl
 		return err
 	}
 
-	if err := util.ForceDeleteInstallations(ctx, log, kclient, config.Kubeconfig, config.LandscaperNamespace); err != nil {
+	if err := util.ForceDeleteInstallations(ctx, log, kclient, config.TestClusterKubeconfig, config.LandscaperNamespace); err != nil {
 		return err
 	}
 
@@ -321,7 +312,7 @@ func installLandscaper(ctx context.Context, config *test.TestConfig) error {
 
 	installArgs := []string{
 		"--kubeconfig",
-		config.Kubeconfig,
+		config.TestClusterKubeconfig,
 		"--landscaper-values",
 		tmpFile.Name(),
 		"--namespace",
@@ -341,46 +332,46 @@ func installLandscaper(ctx context.Context, config *test.TestConfig) error {
 
 // cleanupResources removes all landscaper and laas resource in the laas and test namespace.
 // It also tries to remove all virtual cluster namespaces that are still present in the cluster.
-func cleanupResources(ctx context.Context, log logr.Logger, kclient client.Client, config *test.TestConfig) error {
+func cleanupResources(ctx context.Context, log logr.Logger, hostingClient, laasClient client.Client, config *test.TestConfig) error {
 	// LAAS Namespace
-	if err := util.DeleteValidatingWebhookConfiguration(ctx, kclient, "landscaper-service-validation-webhook", config.LaasNamespace); err != nil {
+	if err := util.DeleteValidatingWebhookConfiguration(ctx, hostingClient, "landscaper-service-validation-webhook", config.LaasNamespace); err != nil {
 		return err
 	}
 
-	if err := util.RemoveFinalizerLandscaperResources(ctx, kclient, config.LaasNamespace); err != nil {
+	if err := util.RemoveFinalizerLandscaperResources(ctx, hostingClient, config.LaasNamespace); err != nil {
 		return err
 	}
 
-	if err := util.RemoveFinalizerLaasResources(ctx, kclient, config.LaasNamespace); err != nil {
+	if err := util.RemoveFinalizerLaasResources(ctx, hostingClient, config.LaasNamespace); err != nil {
 		return err
 	}
 
-	if err := util.CleanupLaasResources(ctx, log, kclient, config.LaasNamespace, config.SleepTime, config.MaxRetries); err != nil {
+	if err := util.CleanupLaasResources(ctx, log, hostingClient, config.LaasNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
 
-	if err := cliutil.DeleteNamespace(kclient, config.LaasNamespace, config.SleepTime, config.MaxRetries); err != nil {
+	if err := cliutil.DeleteNamespace(hostingClient, config.LaasNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
 
 	// Test Namespace
-	if err := util.RemoveFinalizerLaasResources(ctx, kclient, config.TestNamespace); err != nil {
+	if err := util.RemoveFinalizerLaasResources(ctx, hostingClient, config.TestNamespace); err != nil {
 		return err
 	}
 
-	if err := util.CleanupLaasResources(ctx, log, kclient, config.TestNamespace, config.SleepTime, config.MaxRetries); err != nil {
+	if err := util.CleanupLaasResources(ctx, log, hostingClient, config.TestNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
 
-	if err := util.RemoveFinalizerLandscaperResources(ctx, kclient, config.TestNamespace); err != nil {
+	if err := util.RemoveFinalizerLandscaperResources(ctx, hostingClient, config.TestNamespace); err != nil {
 		return err
 	}
 
-	if err := cliutil.DeleteNamespace(kclient, config.TestNamespace, config.SleepTime, config.MaxRetries); err != nil {
+	if err := cliutil.DeleteNamespace(hostingClient, config.TestNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
 
-	if err := util.DeleteVirtualClusterNamespaces(ctx, log, kclient, config.SleepTime, config.MaxRetries); err != nil {
+	if err := util.DeleteVirtualClusterNamespaces(ctx, log, laasClient, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
 

--- a/integration-test/pkg/test/test_runner.go
+++ b/integration-test/pkg/test/test_runner.go
@@ -6,11 +6,13 @@ package test
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
+	"github.com/gardener/landscaper-service/test/integration/pkg/util"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 )
@@ -23,9 +25,67 @@ type SharedTestObjects struct {
 	HostingClusterNamespaces []string
 }
 
+type ClusterClients struct {
+	TestCluster    client.Client
+	HostingCluster client.Client
+}
+
+type ClusterTargets struct {
+	HostingCluster *lsv1alpha1.Target
+	LaasCluster    *lsv1alpha1.Target
+}
+
+func NewClusterClients(config *TestConfig) (*ClusterClients, error) {
+	testClusterCfg, err := clientcmd.BuildConfigFromFlags("", config.TestClusterKubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	testClusterClient, err := client.New(testClusterCfg, client.Options{
+		Scheme: Scheme(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	hostingClusterCfg, err := clientcmd.BuildConfigFromFlags("", config.HostingClusterKubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	hostingClusterClient, err := client.New(hostingClusterCfg, client.Options{
+		Scheme: Scheme(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClusterClients{
+		TestCluster:    testClusterClient,
+		HostingCluster: hostingClusterClient,
+	}, nil
+}
+
+func NewClusterTargets(ctx context.Context, kclient client.Client, config *TestConfig) (*ClusterTargets, error) {
+	hostingClusterTarget, err := util.BuildKubernetesClusterTarget(ctx, kclient, config.TestClusterKubeconfig, "test-target", config.LaasNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build hosting-cluster target: %w", err)
+	}
+
+	laasClusterTarget, err := util.BuildKubernetesClusterTarget(ctx, kclient, config.HostingClusterKubeconfig, "hosting-target", config.LaasNamespace)
+	if err != nil {
+		return nil, fmt.Errorf("cannot build hosting-cluster target: %w", err)
+	}
+
+	return &ClusterTargets{
+		HostingCluster: hostingClusterTarget,
+		LaasCluster:    laasClusterTarget,
+	}, nil
+}
+
 // A TestRunner implements an integration test.
 type TestRunner interface {
-	Init(ctx context.Context, log logr.Logger, kclient client.Client, config *TestConfig, target *lsv1alpha1.Target, testObjects *SharedTestObjects)
+	Init(ctx context.Context, log logr.Logger, config *TestConfig, clusterEndpoints *ClusterClients, clusterTargets *ClusterTargets, testObjects *SharedTestObjects)
 	Name() string
 	Description() string
 	String() string

--- a/integration-test/pkg/test/test_runner.go
+++ b/integration-test/pkg/test/test_runner.go
@@ -27,5 +27,7 @@ type SharedTestObjects struct {
 type TestRunner interface {
 	Init(ctx context.Context, log logr.Logger, kclient client.Client, config *TestConfig, target *lsv1alpha1.Target, testObjects *SharedTestObjects)
 	Name() string
+	Description() string
+	String() string
 	Run() error
 }

--- a/integration-test/pkg/test/test_runner.go
+++ b/integration-test/pkg/test/test_runner.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/landscaper-service/test/integration/pkg/util"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/go-logr/logr"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/landscaper-service/test/integration/pkg/util"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 )

--- a/integration-test/pkg/tests/test_create_deployment.go
+++ b/integration-test/pkg/tests/test_create_deployment.go
@@ -47,6 +47,18 @@ func (r *CreateDeploymentRunner) Name() string {
 	return "CreateDeployment"
 }
 
+func (r *CreateDeploymentRunner) Description() string {
+	description := `This test creates a Landscaper deployment for a tenant and waits until
+the corresponding installation has succeeded. If the installation is in phase succeeded before the test timeout has expired,
+the test succeeds, otherwise the test has failed.
+`
+	return description
+}
+
+func (r *CreateDeploymentRunner) String() string {
+	return r.Name()
+}
+
 func (r *CreateDeploymentRunner) Run() error {
 	r.log.Info("creating landscaper deployment")
 	if err := r.createDeployment(); err != nil {

--- a/integration-test/pkg/tests/test_delete_deployment.go
+++ b/integration-test/pkg/tests/test_delete_deployment.go
@@ -45,6 +45,19 @@ func (r *DeleteDeploymentRunner) Name() string {
 	return "DeleteDeployment"
 }
 
+func (r *DeleteDeploymentRunner) Description() string {
+	description := `This test deletes a Landscaper deployment for a tenant.
+The test waits until the deployment crd has been deleted, which also means, that the
+corresponding installation has been deleted.
+The test fails when the deployment crd hasn't been deleted before the timeout has expired.'
+`
+	return description
+}
+
+func (r *DeleteDeploymentRunner) String() string {
+	return r.Name()
+}
+
 func (r *DeleteDeploymentRunner) Run() error {
 	for _, deployment := range r.testObjects.LandscaperDeployments {
 		if err := r.deleteDeployment(deployment); err != nil {

--- a/integration-test/pkg/tests/test_helm_deployer.go
+++ b/integration-test/pkg/tests/test_helm_deployer.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tests
 
 import (

--- a/integration-test/pkg/tests/test_helm_deployer.go
+++ b/integration-test/pkg/tests/test_helm_deployer.go
@@ -3,11 +3,8 @@ package tests
 import (
 	"context"
 	"fmt"
+
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
-	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
-	lssutils "github.com/gardener/landscaper-service/pkg/utils"
-	"github.com/gardener/landscaper-service/test/integration/pkg/test"
-	"github.com/gardener/landscaper-service/test/integration/pkg/util"
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	cliutil "github.com/gardener/landscapercli/pkg/util"
 	"github.com/go-logr/logr"
@@ -17,6 +14,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
+	lssutils "github.com/gardener/landscaper-service/pkg/utils"
+	"github.com/gardener/landscaper-service/test/integration/pkg/test"
+	"github.com/gardener/landscaper-service/test/integration/pkg/util"
 )
 
 const (

--- a/integration-test/pkg/tests/test_install_laas.go
+++ b/integration-test/pkg/tests/test_install_laas.go
@@ -66,7 +66,7 @@ func (r *InstallLAASTestRunner) Run() error {
 		return err
 	}
 
-	r.log.Info("creating service hostingTarget config")
+	r.log.Info("creating service target config")
 	if err := r.createServiceTargetConfig(); err != nil {
 		return err
 	}

--- a/integration-test/pkg/tests/test_install_laas.go
+++ b/integration-test/pkg/tests/test_install_laas.go
@@ -51,6 +51,18 @@ func (r *InstallLAASTestRunner) Name() string {
 	return "InstallLAAS"
 }
 
+func (r *InstallLAASTestRunner) Description() string {
+	description := `This test installs the Landscaper-As-A-Service controller component.
+The test succeeds when the installation is in phase succeeded before the timeout expires.
+Otherwise the test fails.
+`
+	return description
+}
+
+func (r *InstallLAASTestRunner) String() string {
+	return r.Name()
+}
+
 func (r *InstallLAASTestRunner) Run() error {
 	r.log.Info("creating installation")
 	if err := r.createInstallation(); err != nil {

--- a/integration-test/pkg/tests/test_manifest_deployer.go
+++ b/integration-test/pkg/tests/test_manifest_deployer.go
@@ -1,0 +1,1 @@
+package tests

--- a/integration-test/pkg/tests/test_manifest_deployer.go
+++ b/integration-test/pkg/tests/test_manifest_deployer.go
@@ -1,1 +1,45 @@
 package tests
+
+import (
+	"context"
+	"github.com/gardener/landscaper-service/test/integration/pkg/test"
+	"github.com/go-logr/logr"
+)
+
+type ManifestDeployerTestRunner struct {
+	ctx            context.Context
+	log            logr.Logger
+	config         *test.TestConfig
+	clusterClients *test.ClusterClients
+	clusterTargets *test.ClusterTargets
+	testObjects    *test.SharedTestObjects
+}
+
+func (r *ManifestDeployerTestRunner) Init(
+	ctx context.Context, log logr.Logger, config *test.TestConfig,
+	clusterClients *test.ClusterClients, clusterTargets *test.ClusterTargets, testObjects *test.SharedTestObjects) {
+	r.ctx = ctx
+	r.log = log.WithName(r.Name())
+	r.config = config
+	r.clusterClients = clusterClients
+	r.clusterTargets = clusterTargets
+	r.testObjects = testObjects
+}
+
+func (r *ManifestDeployerTestRunner) Name() string {
+	return "ManifestDeployer"
+}
+
+func (r *ManifestDeployerTestRunner) Description() string {
+	description := `This test creates an installation on the tenant virtual cluster using the Landscaper manifest deployer.
+`
+	return description
+}
+
+func (r *ManifestDeployerTestRunner) String() string {
+	return r.Name()
+}
+
+func (r *ManifestDeployerTestRunner) Run() error {
+	return nil
+}

--- a/integration-test/pkg/tests/test_manifest_deployer.go
+++ b/integration-test/pkg/tests/test_manifest_deployer.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package tests
 
 import (

--- a/integration-test/pkg/tests/test_manifest_deployer.go
+++ b/integration-test/pkg/tests/test_manifest_deployer.go
@@ -2,8 +2,32 @@ package tests
 
 import (
 	"context"
-	"github.com/gardener/landscaper-service/test/integration/pkg/test"
+	"fmt"
+
+	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	cliutil "github.com/gardener/landscapercli/pkg/util"
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
+	lssutils "github.com/gardener/landscaper-service/pkg/utils"
+	"github.com/gardener/landscaper-service/test/integration/pkg/test"
+	"github.com/gardener/landscaper-service/test/integration/pkg/util"
+)
+
+const (
+	manifestTestNamespace         = "example"
+	manifestTestTargetName        = "default-target"
+	manifestTestInstallationName  = "manifest-test"
+	manifestTestComponentName     = "github.com/gardener/landscaper-examples/manifest-deployer/create-configmap"
+	manifestTestComponentVersion  = "v0.1.0"
+	manifestTestRepositoryContext = "eu.gcr.io/gardener-project/landscaper/examples"
+	manifestTestConfigmapName     = "test-configmap"
 )
 
 type ManifestDeployerTestRunner struct {
@@ -41,5 +65,171 @@ func (r *ManifestDeployerTestRunner) String() string {
 }
 
 func (r *ManifestDeployerTestRunner) Run() error {
+	for _, deployment := range r.testObjects.LandscaperDeployments {
+		virtualClient, err := r.createVirtualClusterClient(deployment)
+		if err != nil {
+			return err
+		}
+		virtualClusterNamespace, err := r.prepare(virtualClient)
+		if err != nil {
+			return err
+		}
+		if err := r.createTarget(deployment, virtualClient, virtualClusterNamespace); err != nil {
+			return err
+		}
+		if err := r.createInstallation(deployment, virtualClient, virtualClusterNamespace); err != nil {
+			return err
+		}
+		if err := r.verifyInstallation(deployment, virtualClient, virtualClusterNamespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *ManifestDeployerTestRunner) createVirtualClusterClient(deployment *lssv1alpha1.LandscaperDeployment) (client.Client, error) {
+	r.log.Info("creating virtual cluster client for deployment", "deploymentName", deployment.Name)
+
+	instance := &lssv1alpha1.Instance{}
+	if err := r.clusterClients.TestCluster.Get(r.ctx, deployment.Status.InstanceRef.NamespacedName(), instance); err != nil {
+		return nil, fmt.Errorf("failed to get instance for deployment: %w", err)
+	}
+
+	virtualClient, err := util.BuildKubeClientForInstance(instance, test.Scheme())
+	if err != nil {
+		return nil, err
+	}
+
+	return virtualClient, nil
+}
+
+func (r *ManifestDeployerTestRunner) prepare(virtualClient client.Client) (string, error) {
+	namespace := &corev1.Namespace{}
+	if err := r.clusterClients.TestCluster.Get(r.ctx, types.NamespacedName{Name: manifestTestNamespace}, namespace); err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.log.Error(err, "failed to get test namespace", "namespace", manifestTestNamespace)
+			return "", err
+		}
+	} else {
+		r.log.Info("deleting namespace", "name", manifestTestNamespace)
+		if err := cliutil.DeleteNamespace(r.clusterClients.TestCluster, manifestTestNamespace, r.config.SleepTime, r.config.MaxRetries); err != nil {
+			r.log.Error(err, "failed to delete test namespace", "namespace", manifestTestNamespace)
+			return "", err
+		}
+	}
+
+	namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: manifestTestNamespace,
+		},
+	}
+	r.log.Info("creating namespace in test cluster", "name", manifestTestNamespace)
+	if err := r.clusterClients.TestCluster.Create(r.ctx, namespace); err != nil {
+		r.log.Error(err, "failed to create test namespace", "namespace", manifestTestNamespace)
+		return "", err
+	}
+
+	namespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "manifest-test-",
+		},
+	}
+	r.log.Info("creating namespace in virtual cluster", "generateName", namespace.GenerateName)
+	if err := virtualClient.Create(r.ctx, namespace); err != nil {
+		r.log.Error(err, "failed to create namespace in virtual cluster", "generateName", namespace.GenerateName)
+		return "", err
+	}
+
+	return namespace.Name, nil
+}
+
+func (r *ManifestDeployerTestRunner) createTarget(deployment *lssv1alpha1.LandscaperDeployment, virtualClient client.Client, virtualClusterNamespace string) error {
+	r.log.Info("creating target for deployment", "deploymentName", deployment.Name)
+	if _, err := util.BuildKubernetesClusterTarget(r.ctx, virtualClient, r.config.TestClusterKubeconfig, manifestTestTargetName, virtualClusterNamespace); err != nil {
+		return fmt.Errorf("failed to create target: %w", err)
+	}
+	return nil
+}
+
+func (r *ManifestDeployerTestRunner) createInstallation(deployment *lssv1alpha1.LandscaperDeployment, virtualClient client.Client, virtualClusterNamespace string) error {
+	r.log.Info("creating installation for deployment",
+		"deploymentName", deployment.Name,
+		"installationName", manifestTestInstallationName,
+		"installationNamespace", virtualClusterNamespace)
+
+	installation := &lsv1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      manifestTestInstallationName,
+			Namespace: virtualClusterNamespace,
+			Annotations: map[string]string{
+				lsv1alpha1.OperationAnnotation: string(lsv1alpha1.ReconcileOperation),
+			},
+		},
+		Spec: lsv1alpha1.InstallationSpec{
+			Blueprint: lsv1alpha1.BlueprintDefinition{
+				Reference: &lsv1alpha1.RemoteBlueprintReference{
+					ResourceName: "blueprint",
+				},
+			},
+			ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
+				Reference: &lsv1alpha1.ComponentDescriptorReference{
+					ComponentName: manifestTestComponentName,
+					Version:       manifestTestComponentVersion,
+					RepositoryContext: cdv2.NewUnstructuredType(cdv2.OCIRegistryType, map[string]interface{}{
+						"baseUrl": manifestTestRepositoryContext,
+					}),
+				},
+			},
+			Imports: lsv1alpha1.InstallationImports{
+				Targets: []lsv1alpha1.TargetImport{
+					{
+						Name:   "cluster",
+						Target: fmt.Sprintf("#%s", manifestTestTargetName),
+					},
+				},
+			},
+			ImportDataMappings: map[string]lsv1alpha1.AnyJSON{
+				"configmapName": lssutils.StringToAnyJSON(manifestTestConfigmapName),
+			},
+		},
+		Status: lsv1alpha1.InstallationStatus{},
+	}
+
+	if err := virtualClient.Create(r.ctx, installation); err != nil {
+		return fmt.Errorf("failed to create installation: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ManifestDeployerTestRunner) verifyInstallation(deployment *lssv1alpha1.LandscaperDeployment, virtualClient client.Client, virtualClusterNamespace string) error {
+	r.log.Info("verifying installation for deployment",
+		"deploymentName", deployment.Name,
+		"installationName", manifestTestInstallationName,
+		"installationNamespace", virtualClusterNamespace)
+
+	timeout, err := cliutil.CheckAndWaitUntilLandscaperInstallationSucceeded(
+		virtualClient,
+		types.NamespacedName{Name: manifestTestInstallationName, Namespace: virtualClusterNamespace},
+		r.config.SleepTime, r.config.MaxRetries)
+
+	if err != nil || timeout {
+		installation := &lsv1alpha1.Installation{}
+		if err := virtualClient.Get(r.ctx, types.NamespacedName{Name: manifestTestInstallationName, Namespace: virtualClusterNamespace}, installation); err == nil {
+			r.log.Error(fmt.Errorf("installation failed"), "installation", "last error", installation.Status.LastError)
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for installation to be ready: %w", err)
+	}
+	if timeout {
+		return fmt.Errorf("waiting for installation timed out")
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := r.clusterClients.TestCluster.Get(r.ctx, types.NamespacedName{Name: manifestTestConfigmapName, Namespace: manifestTestNamespace}, configMap); err != nil {
+		return fmt.Errorf("failed to get deployed configmap: %w", err)
+	}
 	return nil
 }

--- a/integration-test/pkg/tests/test_uninstall_laas.go
+++ b/integration-test/pkg/tests/test_uninstall_laas.go
@@ -10,33 +10,29 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	cliutil "github.com/gardener/landscapercli/pkg/util"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/gardener/landscaper-service/test/integration/pkg/test"
 )
 
 type UninstallLAASTestRunner struct {
-	ctx         context.Context
-	log         logr.Logger
-	kclient     client.Client
-	config      *test.TestConfig
-	target      *lsv1alpha1.Target
-	testObjects *test.SharedTestObjects
+	ctx            context.Context
+	log            logr.Logger
+	config         *test.TestConfig
+	clusterClients *test.ClusterClients
+	clusterTargets *test.ClusterTargets
+	testObjects    *test.SharedTestObjects
 }
 
 func (r *UninstallLAASTestRunner) Init(
-	ctx context.Context, log logr.Logger,
-	kclient client.Client, config *test.TestConfig,
-	target *lsv1alpha1.Target, testObjects *test.SharedTestObjects) {
+	ctx context.Context, log logr.Logger, config *test.TestConfig,
+	clusterClients *test.ClusterClients, clusterTargets *test.ClusterTargets, testObjects *test.SharedTestObjects) {
 	r.ctx = ctx
 	r.log = log.WithName(r.Name())
-	r.kclient = kclient
 	r.config = config
-	r.target = target
+	r.clusterClients = clusterClients
+	r.clusterTargets = clusterTargets
 	r.testObjects = testObjects
 }
 
@@ -56,7 +52,7 @@ func (r *UninstallLAASTestRunner) String() string {
 }
 
 func (r *UninstallLAASTestRunner) Run() error {
-	r.log.Info("deleting default service target config")
+	r.log.Info("deleting laas service target config")
 	if err := r.deleteServiceTargetConfig(); err != nil {
 		return err
 	}
@@ -70,10 +66,10 @@ func (r *UninstallLAASTestRunner) Run() error {
 }
 
 func (r *UninstallLAASTestRunner) deleteServiceTargetConfig() error {
-	serviceTargetConfig := r.testObjects.ServiceTargetConfigs[types.NamespacedName{Name: "default-target", Namespace: r.config.LaasNamespace}.String()]
+	serviceTargetConfig := r.testObjects.ServiceTargetConfigs[types.NamespacedName{Name: r.clusterTargets.LaasCluster.Name, Namespace: r.config.LaasNamespace}.String()]
 
-	if err := r.kclient.Delete(r.ctx, serviceTargetConfig); err != nil {
-		return fmt.Errorf("failed to delete service target config: %w", err)
+	if err := r.clusterClients.TestCluster.Delete(r.ctx, serviceTargetConfig); err != nil {
+		return fmt.Errorf("failed to delete service hostingTarget config: %w", err)
 	}
 
 	return nil
@@ -82,12 +78,12 @@ func (r *UninstallLAASTestRunner) deleteServiceTargetConfig() error {
 func (r *UninstallLAASTestRunner) deleteInstallation() error {
 	installation := r.testObjects.Installations[types.NamespacedName{Name: "laas", Namespace: r.config.LaasNamespace}.String()]
 
-	if err := r.kclient.Delete(r.ctx, installation); err != nil {
+	if err := r.clusterClients.TestCluster.Delete(r.ctx, installation); err != nil {
 		return fmt.Errorf("failed to delete laas installation: %w", err)
 	}
 
 	timeout, err := cliutil.CheckAndWaitUntilObjectNotExistAnymore(
-		r.kclient,
+		r.clusterClients.TestCluster,
 		types.NamespacedName{Name: installation.Name, Namespace: installation.Namespace},
 		installation,
 		r.config.SleepTime,

--- a/integration-test/pkg/tests/test_uninstall_laas.go
+++ b/integration-test/pkg/tests/test_uninstall_laas.go
@@ -44,6 +44,17 @@ func (r *UninstallLAASTestRunner) Name() string {
 	return "UninstallLAAS"
 }
 
+func (r *UninstallLAASTestRunner) Description() string {
+	description := `This test uninstalls the Landscaper-As-A-Service controller.
+The test succeeds when the installation has been deleted before the timeout expires.
+`
+	return description
+}
+
+func (r *UninstallLAASTestRunner) String() string {
+	return r.Name()
+}
+
 func (r *UninstallLAASTestRunner) Run() error {
 	r.log.Info("deleting default service target config")
 	if err := r.deleteServiceTargetConfig(); err != nil {

--- a/integration-test/pkg/tests/test_update_deployment.go
+++ b/integration-test/pkg/tests/test_update_deployment.go
@@ -45,6 +45,18 @@ func (r *UpdateDeploymentRunner) Name() string {
 	return "UpdateDeployment"
 }
 
+func (r *UpdateDeploymentRunner) Description() string {
+	description := `This test updates the specification for an existing tenant Landscaper deployment.
+The test succeeds when the corresponding installation is in phase succeeded before the timeout expires.
+Otherwise the test fails.
+`
+	return description
+}
+
+func (r *UpdateDeploymentRunner) String() string {
+	return r.Name()
+}
+
 func (r *UpdateDeploymentRunner) Run() error {
 	for _, deployment := range r.testObjects.LandscaperDeployments {
 		if err := r.updateDeployment(deployment); err != nil {

--- a/integration-test/pkg/tests/test_verify_delete.go
+++ b/integration-test/pkg/tests/test_verify_delete.go
@@ -14,8 +14,9 @@ import (
 
 	"github.com/go-logr/logr"
 
-	"github.com/gardener/landscaper-service/test/integration/pkg/test"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/landscaper-service/test/integration/pkg/test"
 )
 
 type VerifyDeleteRunner struct {

--- a/integration-test/pkg/tests/test_verify_delete.go
+++ b/integration-test/pkg/tests/test_verify_delete.go
@@ -44,7 +44,19 @@ func (r *VerifyDeleteRunner) Init(
 }
 
 func (r *VerifyDeleteRunner) Name() string {
-	return "VerifyDelete"
+	return "VerifyDeploymentDeleted"
+}
+
+func (r *VerifyDeleteRunner) Description() string {
+	description := `This test verifies that a tenant Landscaper deployment has been uninstalled and deleted correctly.
+This test succeeds when the virtual-cluster-namespace of the tenant Landscaper deployment has been deleted before the
+timeout expires. Otherwise the test fails.
+`
+	return description
+}
+
+func (r *VerifyDeleteRunner) String() string {
+	return r.Name()
 }
 
 func (r *VerifyDeleteRunner) Run() error {

--- a/integration-test/pkg/tests/test_verify_deployment.go
+++ b/integration-test/pkg/tests/test_verify_deployment.go
@@ -51,6 +51,19 @@ func (r *VerifyDeploymentRunner) Name() string {
 	return "VerifyDeployment"
 }
 
+func (r *VerifyDeploymentRunner) Description() string {
+	description := `
+This test verifies that a tenant Landscaper deployment has been installed correctly.
+The test succeeds when all required pods (api server, etcd, landscaper ...) are running in the tenant namespace and
+the connection to the virtual cluster can be established. Otherwise the test fails.
+`
+	return description
+}
+
+func (r *VerifyDeploymentRunner) String() string {
+	return r.Name()
+}
+
 func (r *VerifyDeploymentRunner) Run() error {
 	for _, deployment := range r.testObjects.LandscaperDeployments {
 		if err := r.verifyDeployment(deployment); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

* Adds the possibility to specify an additional "hosting" kubeconfig which is used for the tenant landscaper deployments.
This aligns the integration test with the real LAAS landscapes set-up.
* Adds a Manifest Deployer Test which tests an installation on the virtual cluster using the Landscaper Manifest Deployer
* Adds a Helm Deployer Test which tests an installation on the virtual cluster using the Landscaper Helm Deployer
* Improve readability of the integration test output

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
