### PR TITLE
fix schema definition for avs

### DIFF
--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -35,24 +35,28 @@ imports:
   - name: availabiliyMonitoring
     required: false
     type: data
-    properties:
-      selfLandscaperNamespace:
-        type: string
-      periodicCheckInterval:
-        type: string
-      lsHealthCheckTimeout:
-        type: string
+    schema:
+      type: object
+      properties:
+        selfLandscaperNamespace:
+          type: string
+        periodicCheckInterval:
+          type: string
+        lsHealthCheckTimeout:
+          type: string
 
   - name: AVSConfiguration
     required: false
     type: data
-    properties:
-      url:
-        type: string
-      apiKey:
-        type: string
-      timeout:
-        type: string
+    schema:
+      type: object
+      properties:
+        url:
+          type: string
+        apiKey:
+          type: string
+        timeout:
+          type: string
 
   - name: registryPullSecrets
     required: false


### PR DESCRIPTION
**What this PR does / why we need it**:

The imports schema definition was not correct in the landscaper-service blueprint which caused the landscaper to crash.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix imports schema definition for the landscaper-service blueprint.
```
