### PR TITLE
fix indentation for availabilityMontoring config key

### DIFF
--- a/charts/landscaper-service/templates/_helpers.tpl
+++ b/charts/landscaper-service/templates/_helpers.tpl
@@ -123,16 +123,17 @@ landscaperServiceComponent:
   registryPullSecrets:
 {{ toYaml .Values.landscaperservice.landscaperServiceComponent.registryPullSecrets | indent 4 }}
 {{- end }}
-  availabilityMonitoring:
-    availabilityCollectionName: {{ ((.Values.landscaperservice.availabilityMonitoring).availabilityCollectionName) | default "availability" }}
-    availabilityCollectionNamespace: {{ .Release.Namespace }}
-    selfLandscaperNamespace: {{ ((.Values.landscaperservice.availabilityMonitoring).selfLandscaperNamespace) | default "landscaper" }}
-    periodicCheckInterval: {{ ((.Values.landscaperservice.availabilityMonitoring).periodicCheckInterval) | default "1m" }}
-    lsHealthCheckTimeout: {{ ((.Values.landscaperservice.availabilityMonitoring).lsHealthCheckTimeout) | default "5m" }}
-    {{- if (.Values.landscaperservice.availabilityMonitoring).AVSConfiguration }}
-    availabilityService:
-      url: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.url}}
-      apiKey: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.apiKey }}
-      timeout: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.timeout | default "30s" }}
-    {{- end }}
+
+availabilityMonitoring:
+  availabilityCollectionName: {{ ((.Values.landscaperservice.availabilityMonitoring).availabilityCollectionName) | default "availability" }}
+  availabilityCollectionNamespace: {{ .Release.Namespace }}
+  selfLandscaperNamespace: {{ ((.Values.landscaperservice.availabilityMonitoring).selfLandscaperNamespace) | default "landscaper" }}
+  periodicCheckInterval: {{ ((.Values.landscaperservice.availabilityMonitoring).periodicCheckInterval) | default "1m" }}
+  lsHealthCheckTimeout: {{ ((.Values.landscaperservice.availabilityMonitoring).lsHealthCheckTimeout) | default "5m" }}
+  {{- if (.Values.landscaperservice.availabilityMonitoring).AVSConfiguration }}
+  availabilityService:
+    url: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.url}}
+    apiKey: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.apiKey }}
+    timeout: {{ .Values.landscaperservice.availabilityMonitoring.AVSConfiguration.timeout | default "30s" }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The indentation for the `availabilityMontoring` config key in the helm chart templates is incorrect.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
