### PR TITLE
write integration test log to file

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -77,6 +77,8 @@ landscaper-service:
           next_version_callback: '.ci/next_version'
           git_tags:
           - ref_template: 'refs/tags/{VERSION}'
+        scheduling:
+          suppress_parallel_execution: true
       steps:
         run_integration_test:
           depends:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -77,3 +77,21 @@ landscaper-service:
           next_version_callback: '.ci/next_version'
           git_tags:
           - ref_template: 'refs/tags/{VERSION}'
+      steps:
+        run_integration_test:
+          depends:
+            - publish
+            - publish-helm-charts
+          image: 'golang:1.18.5-alpine3.16'
+          execute:
+            - "integration_test"
+          output_dir: 'integration_test'
+        update_release:
+          inputs:
+            INTEGRATION_TEST_PATH: integration_test_path
+          execute:
+            - update_release.py
+          trait_depends:
+            - release
+          depends:
+            - run_integration_test

--- a/.ci/update_release.py
+++ b/.ci/update_release.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import pathlib
+import util
+import os
+
+from github.util import GitHubRepositoryHelper
+
+VERSION_FILE_NAME = 'VERSION'
+
+repo_owner_and_name = util.check_env('SOURCE_GITHUB_REPO_OWNER_AND_NAME')
+repo_dir = util.check_env('MAIN_REPO_DIR')
+
+repo_owner, repo_name = repo_owner_and_name.split('/')
+
+repo_path = pathlib.Path(repo_dir).resolve()
+
+version_file_path = repo_path / VERSION_FILE_NAME
+
+version_file_contents = version_file_path.read_text()
+
+cfg_factory = util.ctx().cfg_factory()
+github_cfg = cfg_factory.github('github_com')
+
+github_repo_helper = GitHubRepositoryHelper(
+    owner=repo_owner,
+    name=repo_name,
+    github_cfg=github_cfg,
+)
+
+gh_release = github_repo_helper.repository.release_from_tag(version_file_contents)
+
+
+try:
+    os.environ['INTEGRATION_TEST_PATH']
+except KeyError:
+    print("No integration test output path found. Output will not be added to release")
+else:
+    integration_test_path = util.check_env('INTEGRATION_TEST_PATH')
+    integration_test_path = pathlib.Path(integration_test_path).resolve()
+    integration_test_path = integration_test_path / "integration_test.log"
+    gh_release.upload_asset(
+        content_type='text/plain',
+        name=f'integration-test-result-{version_file_contents}.txt',
+        asset=integration_test_path.open(mode='rb'),
+    )

--- a/.landscaper/component-references.yaml
+++ b/.landscaper/component-references.yaml
@@ -1,5 +1,5 @@
 ---
 componentName: github.com/gardener/landscaper/landscaper-service
 name: landscaper-service
-version: v0.31.0
+version: v0.35.0
 ...

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -17,7 +17,8 @@ PROJECT_ROOT="$(dirname $0)/.."
 TEST_CLUSTER="laas-integration-test"
 HOSTING_CLUSTER="laas-integration-test-target"
 TARGET_CLUSTER_PROVIDER="gcp"
-LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
+# LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
+LAAS_REPOSITORY="eu.gcr.io/gardener-project/development"
 LAAS_VERSION="$(${PROJECT_ROOT}/hack/get-version.sh)"
 REPO_AUTH_URL="https://eu.gcr.io"
 REPO_CTX_BASE_URL="eu.gcr.io/sap-se-gcr-k8s-private"
@@ -68,4 +69,5 @@ pip3 install -q --upgrade pip
 echo "Running pip3 install gardener-cicd-libs"
 pip3 install -q gardener-cicd-libs
 
-"${PROJECT_ROOT}/hack/integration-test.py"
+FULL_INTEGRATION_TEST_PATH="$(realpath $INTEGRATION_TEST_PATH)"
+"${PROJECT_ROOT}/hack/integration-test.py" | tee $FULL_INTEGRATION_TEST_PATH/integration_test.log

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+set -o pipefail
 
 apk add --no-cache --no-progress bash
 


### PR DESCRIPTION
**What this PR does / why we need it**:

* In the integration test the components are now pulled from the public gardener dev OCI repository.
For this to work, the landscaper version has to be upated to v0.35.0 to able to pull the referenced virtual-garden component.
* The integration tests are now active in the release pipeline job.
* The integration test logs are now collected in the release pipeline job and published in the GitHub release. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Update landscaper version to v0.35.0
```
