### PR TITLE
Fix AV Monitoring

### DIFF
--- a/pkg/controllers/avmonitorregistration/controller.go
+++ b/pkg/controllers/avmonitorregistration/controller.go
@@ -10,7 +10,6 @@ import (
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,9 +55,6 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	instances := &lssv1alpha1.InstanceList{}
 	if err := c.Client().List(ctx, instances); err != nil {
 		logger.Error(err, "failed loading instances")
-		if apierrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllers/avuploader/controller.go
+++ b/pkg/controllers/avuploader/controller.go
@@ -15,7 +15,6 @@ import (
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 
@@ -64,9 +63,6 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	availabilityCollection := &lssv1alpha1.AvailabilityCollection{}
 	if err := c.Client().Get(ctx, req.NamespacedName, availabilityCollection); err != nil {
 		logger.Error(err, "failed loading AvailabilityCollection")
-		if apierrors.IsNotFound(err) {
-			return reconcile.Result{}, nil
-		}
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllers/healthwatcher/controllger.go
+++ b/pkg/controllers/healthwatcher/controllger.go
@@ -74,7 +74,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	availabilityCollection := &lssv1alpha1.AvailabilityCollection{}
 	if err := c.Client().Get(ctx, req.NamespacedName, availabilityCollection); err != nil {
 		logger.Error(err, "failed loading AvailabilityCollection")
-		return reconcile.Result{RequeueAfter: c.Config().AvailabilityMonitoring.PeriodicCheckInterval.Duration}, err
+		return reconcile.Result{}, err
 	}
 
 	//dont run if spec has not changed and we are not in time yet
@@ -93,7 +93,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		instance := &lssv1alpha1.Instance{}
 		if err := c.Client().Get(ctx, apitypes.NamespacedName{Name: instanceRefToWatch.Name, Namespace: instanceRefToWatch.Namespace}, instance); err != nil {
 			logger.Error(err, "failed loading instance")
-			return reconcile.Result{RequeueAfter: c.Config().AvailabilityMonitoring.PeriodicCheckInterval.Duration}, err
+			return reconcile.Result{}, err
 		}
 
 		availabilityInstance := lssv1alpha1.AvailabilityInstance{
@@ -177,7 +177,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	//write to status
 	if err := c.Client().Status().Update(ctx, availabilityCollection); err != nil {
 		logger.Error(err, "unable to update AvailabilityCollection status")
-		return reconcile.Result{RequeueAfter: c.Config().AvailabilityMonitoring.PeriodicCheckInterval.Duration}, fmt.Errorf("unable to update availability collection: %w", err)
+		return reconcile.Result{}, fmt.Errorf("unable to update availability collection: %w", err)
 	}
 
 	//Requeue to run again


### PR DESCRIPTION
**What this PR does / why we need it**:
This change prevents any exit path of a reconcile that does not requeues the reconcilitation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
av monitoring stabilised (reconcile loop not exited without a requeue scheduled)
```
