### PR TITLE
add ignore operation annotation

### DIFF
--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/constants.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/constants.go
@@ -12,4 +12,11 @@ const (
 	ShootInstanceNameLabel      = "shoot.landscaper-service.gardener.cloud/instanceName"
 	ShootInstanceNamespaceLabel = "shoot.landscaper-service.gardener.cloud/instanceNamespace"
 	ShootInstanceIDLabel        = "shoot.landscaper-service.gardener.cloud/instanceId"
+
+	// LandscaperServiceOperationAnnotation is the operation annotation.
+	LandscaperServiceOperationAnnotation = "landscaper-service.gardener.cloud/operation"
+	// LandscaperServiceOperationIgnore can be set as the landscaper service operation annotation.
+	// When set at landscaper deployments, the annotation will be inherited to the corresponding instance
+	// and prevents its reconciliation until removed.
+	LandscaperServiceOperationIgnore = "ignore"
 )

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/utils/utils.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
@@ -48,4 +50,37 @@ func RemoveReference(refList []lssv1alpha1.ObjectReference, ref *lssv1alpha1.Obj
 		}
 	}
 	return refList
+}
+
+// HasOperationAnnotation returns true if the object has provided operation annotation set.
+func HasOperationAnnotation(object client.Object, operation string) bool {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	operationAnnotation, ok := annotations[lssv1alpha1.LandscaperServiceOperationAnnotation]
+	if !ok {
+		return false
+	}
+
+	return operationAnnotation == operation
+}
+
+// SetOperationAnnotation sets the provided operation annotation.
+func SetOperationAnnotation(object client.Object, operation string) {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+		object.SetAnnotations(annotations)
+	}
+	annotations[lssv1alpha1.LandscaperServiceOperationAnnotation] = operation
+}
+
+// RemoveOperationAnnotation removes the operation annotation if it exists.
+func RemoveOperationAnnotation(object client.Object) {
+	annotations := object.GetAnnotations()
+	if annotations != nil {
+		delete(annotations, lssv1alpha1.LandscaperServiceOperationAnnotation)
+	}
 }

--- a/pkg/apis/core/v1alpha1/constants.go
+++ b/pkg/apis/core/v1alpha1/constants.go
@@ -12,4 +12,11 @@ const (
 	ShootInstanceNameLabel      = "shoot.landscaper-service.gardener.cloud/instanceName"
 	ShootInstanceNamespaceLabel = "shoot.landscaper-service.gardener.cloud/instanceNamespace"
 	ShootInstanceIDLabel        = "shoot.landscaper-service.gardener.cloud/instanceId"
+
+	// LandscaperServiceOperationAnnotation is the operation annotation.
+	LandscaperServiceOperationAnnotation = "landscaper-service.gardener.cloud/operation"
+	// LandscaperServiceOperationIgnore can be set as the landscaper service operation annotation.
+	// When set at landscaper deployments, the annotation will be inherited to the corresponding instance
+	// and prevents its reconciliation until removed.
+	LandscaperServiceOperationIgnore = "ignore"
 )

--- a/pkg/controllers/instances/controller.go
+++ b/pkg/controllers/instances/controller.go
@@ -27,6 +27,7 @@ import (
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
 	"github.com/gardener/landscaper-service/pkg/operation"
+	"github.com/gardener/landscaper-service/pkg/utils"
 )
 
 // Controller is the instances controller
@@ -119,6 +120,11 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// reconcile delete
 	if !instance.DeletionTimestamp.IsZero() {
 		return reconcile.Result{}, errHdl(ctx, c.HandleDeleteFunc(ctx, instance))
+	}
+
+	if utils.HasOperationAnnotation(instance, lssv1alpha1.LandscaperServiceOperationIgnore) {
+		logger.Info("instance has ignore annotation, skipping reconcile")
+		return reconcile.Result{}, nil
 	}
 
 	// reconcile

--- a/pkg/controllers/instances/reconcile_test.go
+++ b/pkg/controllers/instances/reconcile_test.go
@@ -333,4 +333,19 @@ var _ = Describe("Reconcile", func() {
 		Expect(instance.Status.LastError.Message).To(Equal(message))
 		Expect(instance.Status.LastError.LastUpdateTime.Time).Should(BeTemporally(">", instance.Status.LastError.LastTransitionTime.Time))
 	})
+
+	It("should respect the ignore operation annotation", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test4")
+		Expect(err).ToNot(HaveOccurred())
+
+		instance := state.GetInstance("test")
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(instance), instance)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(instance), instance)).To(Succeed())
+
+		Expect(instance.Status.TargetRef).To(BeNil())
+		Expect(instance.Status.InstallationRef).To(BeNil())
+	})
 })

--- a/pkg/controllers/instances/testdata/reconcile/test4/instance.yaml
+++ b/pkg/controllers/instances/testdata/reconcile/test4/instance.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: Instance
+metadata:
+  name: "test"
+  namespace: {{ .Namespace }}
+  annotations:
+    landscaper-service.gardener.cloud/operation: ignore
+spec:
+  tenantId: "12345"
+  id: "abcdef"
+  purpose: "test"
+  landscaperConfiguration:
+    deployers:
+      - helm
+      - manifest
+      - container
+  serviceTargetConfigRef:
+    name: default
+    namespace: {{ .Namespace }}

--- a/pkg/controllers/landscaperdeployments/reconcile_test.go
+++ b/pkg/controllers/landscaperdeployments/reconcile_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/landscaper-service/pkg/utils"
+
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
@@ -351,5 +353,34 @@ var _ = Describe("Reconcile", func() {
 		Expect(deployment.Status.LastError.Reason).To(Equal(reason))
 		Expect(deployment.Status.LastError.Message).To(Equal(message))
 		Expect(deployment.Status.LastError.LastUpdateTime.Time).Should(BeTemporally(">", deployment.Status.LastError.LastTransitionTime.Time))
+	})
+
+	It("should respect the ignore operation annotation", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test6")
+		Expect(err).ToNot(HaveOccurred())
+
+		deployment := state.GetDeployment("test")
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(deployment))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(deployment))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+		Expect(deployment.Status.InstanceRef).ToNot(BeNil())
+
+		instance := &lssv1alpha1.Instance{}
+		err = testenv.Client.Get(ctx, types.NamespacedName{Name: deployment.Status.InstanceRef.Name, Namespace: deployment.Status.InstanceRef.Namespace}, instance)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(utils.HasOperationAnnotation(instance, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeTrue())
+
+		utils.RemoveOperationAnnotation(deployment)
+		err = testenv.Client.Update(ctx, deployment)
+		Expect(err).ToNot(HaveOccurred())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(deployment))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+
+		err = testenv.Client.Get(ctx, types.NamespacedName{Name: deployment.Status.InstanceRef.Name, Namespace: deployment.Status.InstanceRef.Namespace}, instance)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(utils.HasOperationAnnotation(instance, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeFalse())
 	})
 })

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/deployment.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: LandscaperDeployment
+metadata:
+  name: "test"
+  namespace: {{ .Namespace }}
+  annotations:
+    landscaper-service.gardener.cloud/operation: ignore
+spec:
+  tenantId: "12345"
+  purpose: "test"
+  landscaperConfiguration:
+    deployers:
+      - helm
+      - manifest
+      - container
+  componentReference:
+    version: v0.16.0

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/servicetargetconf.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/servicetargetconf.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: target
+  namespace: {{ .Namespace }}
+type: Opaque
+stringData:
+  kubeconfig: |
+    dummy
+---
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: ServiceTargetConfig
+
+metadata:
+  name: config1
+  namespace: {{ .Namespace }}
+  labels:
+    config.landscaper-service.gardener.cloud/visible: "true"
+    config.landscaper-service.gardener.cloud/region: eu
+
+spec:
+  providerType: gcp
+  priority: 10
+
+  secretRef:
+    name: target
+    namespace: {{ .Namespace }}
+    key: kubeconfig

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
@@ -48,4 +50,37 @@ func RemoveReference(refList []lssv1alpha1.ObjectReference, ref *lssv1alpha1.Obj
 		}
 	}
 	return refList
+}
+
+// HasOperationAnnotation returns true if the object has provided operation annotation set.
+func HasOperationAnnotation(object client.Object, operation string) bool {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+
+	operationAnnotation, ok := annotations[lssv1alpha1.LandscaperServiceOperationAnnotation]
+	if !ok {
+		return false
+	}
+
+	return operationAnnotation == operation
+}
+
+// SetOperationAnnotation sets the provided operation annotation.
+func SetOperationAnnotation(object client.Object, operation string) {
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+		object.SetAnnotations(annotations)
+	}
+	annotations[lssv1alpha1.LandscaperServiceOperationAnnotation] = operation
+}
+
+// RemoveOperationAnnotation removes the operation annotation if it exists.
+func RemoveOperationAnnotation(object client.Object) {
+	annotations := object.GetAnnotations()
+	if annotations != nil {
+		delete(annotations, lssv1alpha1.LandscaperServiceOperationAnnotation)
+	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	"github.com/gardener/landscaper-service/pkg/utils"
@@ -83,5 +85,52 @@ var _ = Describe("Utils", func() {
 
 		newList = utils.RemoveReference(newList, &toRemove)
 		Expect(newList).To(HaveLen(0))
+	})
+
+	It("should detect operation annotations", func() {
+		secret := &corev1.Secret{}
+		Expect(utils.HasOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeFalse())
+
+		secret.ObjectMeta.Annotations = map[string]string{
+			"someKey": "someVar",
+		}
+		Expect(utils.HasOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeFalse())
+
+		secret.ObjectMeta.Annotations[lssv1alpha1.LandscaperServiceOperationAnnotation] = "invalid"
+		Expect(utils.HasOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeFalse())
+
+		secret.ObjectMeta.Annotations[lssv1alpha1.LandscaperServiceOperationAnnotation] = lssv1alpha1.LandscaperServiceOperationIgnore
+		Expect(utils.HasOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)).To(BeTrue())
+	})
+
+	It("should set operation annotation", func() {
+		secret := &corev1.Secret{}
+		utils.SetOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue(lssv1alpha1.LandscaperServiceOperationAnnotation, lssv1alpha1.LandscaperServiceOperationIgnore))
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"someKey": "someVar",
+				},
+			},
+		}
+		utils.SetOperationAnnotation(secret, lssv1alpha1.LandscaperServiceOperationIgnore)
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue(lssv1alpha1.LandscaperServiceOperationAnnotation, lssv1alpha1.LandscaperServiceOperationIgnore))
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("someKey", "someVar"))
+	})
+
+	It("should remove operation annotation", func() {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"someKey": "someVar",
+					lssv1alpha1.LandscaperServiceOperationAnnotation: lssv1alpha1.LandscaperServiceOperationIgnore,
+				},
+			},
+		}
+		utils.RemoveOperationAnnotation(secret)
+		Expect(secret.ObjectMeta.Annotations).ToNot(HaveKeyWithValue(lssv1alpha1.LandscaperServiceOperationAnnotation, lssv1alpha1.LandscaperServiceOperationIgnore))
+		Expect(secret.ObjectMeta.Annotations).To(HaveKeyWithValue("someKey", "someVar"))
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the ignore operation annotation.
This annotation can be set at a Landscaper Deployment CRD. When set, the annotated resource will not be reconciled until the annotation is removed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add ignore operation annotation.
```
