### PR TITLE
set instance reference first in status before any other operations

### DIFF
--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/deployment.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/deployment.yaml
@@ -17,5 +17,3 @@ spec:
       - helm
       - manifest
       - container
-  componentReference:
-    version: v0.16.0

--- a/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/servicetargetconf.yaml
+++ b/pkg/controllers/landscaperdeployments/testdata/reconcile/test6/servicetargetconf.yaml
@@ -20,13 +20,13 @@ metadata:
   namespace: {{ .Namespace }}
   labels:
     config.landscaper-service.gardener.cloud/visible: "true"
-    config.landscaper-service.gardener.cloud/region: eu
 
 spec:
-  providerType: gcp
   priority: 10
 
   secretRef:
     name: target
     namespace: {{ .Namespace }}
     key: kubeconfig
+
+  ingressDomain: "ingress.mycluster.external"


### PR DESCRIPTION
**What this PR does / why we need it**:

When the Instance resource is created, the reference to it is set in the LandscaperDeployment status.
Before this PR an additional operation was happening between creation of the Instance resource and the setting of the reference. When the in-between-step failed, it could lead to the instance being created but not associated with the LandscaperDeployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Set instance reference first in LandscaperDeployment status before any other operations.
```
