### PR TITLE
update ServiceTargetConfig documentation

### DIFF
--- a/docs/gettingstarted/configure-service-targets.md
+++ b/docs/gettingstarted/configure-service-targets.md
@@ -37,9 +37,10 @@ kubectl apply -f secret.yaml
 
 The secret that was just created, is then referenced in a ServiceTargetConfig.
 The `spec.secretRef` field contains the name, the namespace of the secret and the key that contains the kubeconfig.
-The visibility label `config.landscaper-service.gardener.cloud/visible` needs to be set with the value `"true"`.
+The `spec.ingressDomain` field has to be set to the correct url under which the ingress controller at the referenced target cluster is available.
+For the ingress domain field contains only the domain name, the protocol (`https://`) has to be omitted.
 
-:warning: Attention: It is important that the `spec.providerType` matches the infrastructure provider type of the targeted kubernetes cluster.
+The visibility label `config.landscaper-service.gardener.cloud/visible` needs to be set with the value `"true"`.
 
 The ServiceTargetConfig can be created in any namespace. It is however recommended, to create it in a namespace that is only accessible to landscaper service administrators.
 
@@ -56,6 +57,8 @@ metadata:
 spec:
   priority: 10
 
+  ingressDomain: ingress.mydomain.net
+  
   secretRef:
     name: default-target
     namespace: laas-system

--- a/docs/usage/ServiceTargetConfigs.md
+++ b/docs/usage/ServiceTargetConfigs.md
@@ -73,7 +73,7 @@ The more instances that are referenced by a ServiceTargetConfig, the lower the e
 ## Ingress Domain
 
 The `spec.ingressDomain` field is a string specifying the ingress domain of the referenced target cluster.
-The ingress domain has to be configured for the target cluster so that an ingress resource can be created for the Landscaper Webhooks Server.
+The ingress domain of the target cluster has to be configured so that an ingress resource can be created as an endpoint for the Webhook Server of every Landscaper instance.
 
 ## Secret Reference
 

--- a/docs/usage/ServiceTargetConfigs.md
+++ b/docs/usage/ServiceTargetConfigs.md
@@ -27,6 +27,8 @@ metadata:
 spec:
   priority: 10
 
+  ingressDomain: ingress.mydomain.net
+
   secretRef:
     name: default-target
     namespace: laas-system
@@ -68,6 +70,10 @@ To calculate the effective priority when scheduling Instances is calculated by d
 (`spec.priority/(len(status.instanceRefs) + 1)`).
 The more instances that are referenced by a ServiceTargetConfig, the lower the effective priority becomes.
 
+## Ingress Domain
+
+The `spec.ingressDomain` field is a string specifying the ingress domain of the referenced target cluster.
+The ingress domain has to be configured for the target cluster so that an ingress resource can be created for the Landscaper Webhooks Server.
 
 ## Secret Reference
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the documentation regarding `ServiceTargetConfig`resources, reflecting the latest changes switching to Shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
NONE
```
