### PR TITLE
run integration test only when 'run-int-tests' is in git commit message

### DIFF
--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -2,5 +2,19 @@
 
 PROJECT_ROOT="$(dirname $0)/.."
 
-echo "laas integration test"
-${PROJECT_ROOT}/hack/integration-test.sh
+echo "check if integration tests should be started"
+
+if ! which git 1>/dev/null; then
+  echo "Installing git... "
+  apk add --no-cache --no-progress git
+fi
+
+GIT_COMMENT=$(git show -s --format=%s)
+echo "git comment: " $GIT_COMMENT
+
+if git show -s --format=%s | grep run-int-tests; then
+  echo "laas integration test"
+  ${PROJECT_ROOT}/hack/integration-test.sh
+else
+    echo "integration tests are skipped"
+fi

--- a/.ci/integration_test
+++ b/.ci/integration_test
@@ -2,19 +2,5 @@
 
 PROJECT_ROOT="$(dirname $0)/.."
 
-echo "check if integration tests should be started"
-
-if ! which git 1>/dev/null; then
-  echo "Installing git... "
-  apk add --no-cache --no-progress git
-fi
-
-GIT_COMMENT=$(git show -s --format=%s)
-echo "git comment: " $GIT_COMMENT
-
-if git show -s --format=%s | grep run-int-tests; then
-  echo "laas integration test"
-  ${PROJECT_ROOT}/hack/integration-test.sh
-else
-    echo "integration tests are skipped"
-fi
+echo "laas integration test"
+${PROJECT_ROOT}/hack/integration-test.sh

--- a/.ci/integration_test_pr
+++ b/.ci/integration_test_pr
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+PROJECT_ROOT="$(dirname $0)/.."
+
+echo "check if integration tests should be started"
+
+if ! which git 1>/dev/null; then
+  echo "Installing git... "
+  apk add --no-cache --no-progress git
+fi
+
+GIT_COMMENT=$(git show -s --format=%s)
+echo "git comment: " $GIT_COMMENT
+
+if git show -s --format=%s | grep run-int-tests; then
+  echo "laas integration test"
+  ${PROJECT_ROOT}/hack/integration-test.sh
+else
+    echo "integration tests are skipped"
+fi

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -62,7 +62,7 @@ landscaper-service:
           - publish-helm-charts
           image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.18.6-alpine3.16'
           execute:
-          - "integration_test"
+          - "integration_test_pr"
           output_dir: 'integration_test'
       traits:
         pull-request: ~


### PR DESCRIPTION
**What this PR does / why we need it**:

Running the integration test can take quite some time and isn't even needed when there are no or no significant code changes.

With this change the integration test runs per default in the head-update and release pipeline jobs.
In the pull request validation jobs, the integration tests are only run when the commit message contains the string `run-int-tests`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
