### PR TITLE
use different shoot clusters for pull request integration tests

### DIFF
--- a/.ci/integration_test_pr
+++ b/.ci/integration_test_pr
@@ -17,7 +17,7 @@ echo "git comment: " $GIT_COMMENT
 
 if git show -s --format=%s | grep run-int-tests; then
   echo "laas integration test"
-  ${PROJECT_ROOT}/hack/integration-test.sh
+  ${PROJECT_ROOT}/hack/integration-test.sh pull-request
 else
   echo "integration tests are skipped"
 fi

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -8,8 +8,16 @@ set +e
 set -o pipefail
 
 PROJECT_ROOT="$(dirname $0)/.."
-TEST_CLUSTER="laas-integration-test"
-HOSTING_CLUSTER="laas-integration-test-target"
+ARG=$1
+
+if [[ $ARG == "pull-request" ]]; then
+  TEST_CLUSTER="laas-integration-test"
+  HOSTING_CLUSTER="laas-integration-test-target"
+else
+  TEST_CLUSTER="laas-integration-test-pr"
+  HOSTING_CLUSTER="laas-integration-test-target-pr"
+fi
+
 GARDENER_CLUSTER="laas-integration-test-service-account"
 # LAAS_REPOSITORY="eu.gcr.io/sap-se-gcr-k8s-private/cnudie/gardener/development"
 LAAS_REPOSITORY="eu.gcr.io/gardener-project/development"

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -11,11 +11,11 @@ PROJECT_ROOT="$(dirname $0)/.."
 ARG=$1
 
 if [[ $ARG == "pull-request" ]]; then
-  TEST_CLUSTER="laas-integration-test"
-  HOSTING_CLUSTER="laas-integration-test-target"
-else
   TEST_CLUSTER="laas-integration-test-pr"
   HOSTING_CLUSTER="laas-integration-test-target-pr"
+else
+  TEST_CLUSTER="laas-integration-test"
+  HOSTING_CLUSTER="laas-integration-test-target"
 fi
 
 GARDENER_CLUSTER="laas-integration-test-service-account"


### PR DESCRIPTION
**What this PR does / why we need it**:
Use different shoot clusters for pull request integration tests.
This should fix head-update and release build breaking pull request validatiion builds and vice versa.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
