### PR TITLE
Deep equals for sidecar config in installation spec

### DIFF
--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -543,6 +543,18 @@ func deepEqualInstallationSpec(specA, specB *lsv1alpha1.InstallationSpec) bool {
 		return false
 	}
 
+	sidecarConfigA := make(map[string]interface{})
+	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.SidecarConfigImportName].RawMessage, &sidecarConfigA); err != nil {
+		return false
+	}
+	sidecarConfigB := make(map[string]interface{})
+	if err := json.Unmarshal(specB.ImportDataMappings[lsinstallation.SidecarConfigImportName].RawMessage, &sidecarConfigB); err != nil {
+		return false
+	}
+	if !reflect.DeepEqual(sidecarConfigA, sidecarConfigB) {
+		return false
+	}
+
 	_, policyExistsA := specA.ImportDataMappings[lsinstallation.AuditPolicyImportName]
 	_, policyExistsB := specB.ImportDataMappings[lsinstallation.AuditPolicyImportName]
 
@@ -569,6 +581,8 @@ func deepEqualInstallationSpec(specA, specB *lsv1alpha1.InstallationSpec) bool {
 	delete(specB.ImportDataMappings, lsinstallation.RegistryConfigImportName)
 	delete(specA.ImportDataMappings, lsinstallation.ShootConfigImportName)
 	delete(specB.ImportDataMappings, lsinstallation.ShootConfigImportName)
+	delete(specA.ImportDataMappings, lsinstallation.SidecarConfigImportName)
+	delete(specB.ImportDataMappings, lsinstallation.SidecarConfigImportName)
 
 	return reflect.DeepEqual(specA, specB)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adapts the deep equals method for Installation specs. The comparison of sidecarConfigs is done in the same way as for the other `RawMesssage` fields.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
