### PR TITLE
replace installation spec deep equal function with generic implementation

### DIFF
--- a/pkg/controllers/instances/installation_equals.go
+++ b/pkg/controllers/instances/installation_equals.go
@@ -14,43 +14,32 @@ import (
 
 // InstallationSpecDeepEquals test whether two installation specs are deeply equal.
 func InstallationSpecDeepEquals(specA, specB *lsv1alpha1.InstallationSpec) bool {
-	testImportDataMappings := func(specA, specB *lsv1alpha1.InstallationSpec) bool {
-		for k, v := range specA.ImportDataMappings {
-			if _, ok := specB.ImportDataMappings[k]; !ok {
-				return false
-			}
-
-			var importDataMappingA interface{}
-			if err := json.Unmarshal(v.RawMessage, &importDataMappingA); err != nil {
-				return false
-			}
-
-			var importDataMappingB interface{}
-			if err := json.Unmarshal(specB.ImportDataMappings[k].RawMessage, &importDataMappingB); err != nil {
-				return false
-			}
-
-			if !reflect.DeepEqual(importDataMappingA, importDataMappingB) {
-				return false
-			}
-
-			delete(specA.ImportDataMappings, k)
-			delete(specB.ImportDataMappings, k)
-		}
-
-		return true
-	}
-
 	if len(specA.ImportDataMappings) != len(specB.ImportDataMappings) {
 		return false
 	}
 
-	if !testImportDataMappings(specA, specB) {
-		return false
+	for k, v := range specA.ImportDataMappings {
+		if _, ok := specB.ImportDataMappings[k]; !ok {
+			return false
+		}
+
+		var importDataMappingA interface{}
+		if err := json.Unmarshal(v.RawMessage, &importDataMappingA); err != nil {
+			return false
+		}
+
+		var importDataMappingB interface{}
+		if err := json.Unmarshal(specB.ImportDataMappings[k].RawMessage, &importDataMappingB); err != nil {
+			return false
+		}
+
+		if !reflect.DeepEqual(importDataMappingA, importDataMappingB) {
+			return false
+		}
 	}
-	if !testImportDataMappings(specB, specA) {
-		return false
-	}
+
+	specA.ImportDataMappings = nil
+	specB.ImportDataMappings = nil
 
 	return reflect.DeepEqual(specA, specB)
 }

--- a/pkg/controllers/instances/installation_equals.go
+++ b/pkg/controllers/instances/installation_equals.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package instances
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/util/json"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+)
+
+// InstallationSpecDeepEquals test whether two installation specs are deeply equal.
+func InstallationSpecDeepEquals(specA, specB *lsv1alpha1.InstallationSpec) bool {
+	testImportDataMappings := func(specA, specB *lsv1alpha1.InstallationSpec) bool {
+		for k, v := range specA.ImportDataMappings {
+			if _, ok := specB.ImportDataMappings[k]; !ok {
+				return false
+			}
+
+			var importDataMappingA interface{}
+			if err := json.Unmarshal(v.RawMessage, &importDataMappingA); err != nil {
+				return false
+			}
+
+			var importDataMappingB interface{}
+			if err := json.Unmarshal(specB.ImportDataMappings[k].RawMessage, &importDataMappingB); err != nil {
+				return false
+			}
+
+			if !reflect.DeepEqual(importDataMappingA, importDataMappingB) {
+				return false
+			}
+
+			delete(specA.ImportDataMappings, k)
+			delete(specB.ImportDataMappings, k)
+		}
+
+		return true
+	}
+
+	if !testImportDataMappings(specA, specB) {
+		return false
+	}
+	if !testImportDataMappings(specB, specA) {
+		return false
+	}
+
+	return reflect.DeepEqual(specA, specB)
+}

--- a/pkg/controllers/instances/installation_equals.go
+++ b/pkg/controllers/instances/installation_equals.go
@@ -41,6 +41,10 @@ func InstallationSpecDeepEquals(specA, specB *lsv1alpha1.InstallationSpec) bool 
 		return true
 	}
 
+	if len(specA.ImportDataMappings) != len(specB.ImportDataMappings) {
+		return false
+	}
+
 	if !testImportDataMappings(specA, specB) {
 		return false
 	}

--- a/pkg/controllers/instances/installation_equals_test.go
+++ b/pkg/controllers/instances/installation_equals_test.go
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package instances_test
+
+import (
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper-service/pkg/controllers/instances"
+	"github.com/gardener/landscaper-service/pkg/utils"
+)
+
+func createDummyInstallationSpec() *lsv1alpha1.InstallationSpec {
+	return &lsv1alpha1.InstallationSpec{
+		ComponentDescriptor: &lsv1alpha1.ComponentDescriptorDefinition{
+			Reference: &lsv1alpha1.ComponentDescriptorReference{
+				ComponentName: "compa",
+				Version:       "v0.0.1",
+			},
+		},
+		Context: "test",
+		Blueprint: lsv1alpha1.BlueprintDefinition{
+			Reference: &lsv1alpha1.RemoteBlueprintReference{
+				ResourceName: "blueprint",
+			},
+		},
+		Imports: lsv1alpha1.InstallationImports{
+			Data: []lsv1alpha1.DataImport{
+				{
+					Name:    "testimport",
+					DataRef: "testimport",
+				},
+			},
+			Targets: []lsv1alpha1.TargetImport{
+				{
+					Name:   "testtarget",
+					Target: "testtarget",
+				},
+			},
+		},
+		Exports: lsv1alpha1.InstallationExports{
+			Data: []lsv1alpha1.DataExport{
+				{
+					Name:    "dataexport",
+					DataRef: "dataexport",
+				},
+			},
+			Targets: []lsv1alpha1.TargetExport{
+				{
+					Name:   "targetexport",
+					Target: "targetexport",
+				},
+			},
+		},
+	}
+}
+
+var _ = Describe("Installation Equals", func() {
+	It("should correctly test equality of empty specs", func() {
+		specA := &lsv1alpha1.InstallationSpec{}
+		specB := &lsv1alpha1.InstallationSpec{}
+
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeTrue())
+	})
+
+	It("should correctly test equality of identical specs", func() {
+		specA := createDummyInstallationSpec()
+		specB := createDummyInstallationSpec()
+
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeTrue())
+	})
+
+	It("should correctly test inequality of different specs", func() {
+		specA := createDummyInstallationSpec()
+		specB := createDummyInstallationSpec()
+
+		specB.Imports.Data = append(specB.Imports.Data, lsv1alpha1.DataImport{Name: "foo"})
+
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA = createDummyInstallationSpec()
+		specB = createDummyInstallationSpec()
+
+		specA.Exports.Targets = []lsv1alpha1.TargetExport{}
+
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA = createDummyInstallationSpec()
+		specB = createDummyInstallationSpec()
+
+		specB.ComponentDescriptor.Reference.ComponentName = "invalid"
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+	})
+
+	It("should correctly test equality of equal specs with import data mappings", func() {
+		specA := createDummyInstallationSpec()
+		specB := createDummyInstallationSpec()
+
+		importDataMappings := map[string]lsv1alpha1.AnyJSON{
+			"a": utils.StringToAnyJSON("a-string"),
+			"b": utils.BoolToAnyJSON(true),
+			"c": utils.IntToAnyJSON(42),
+		}
+
+		specA.ImportDataMappings = importDataMappings
+		specB.ImportDataMappings = importDataMappings
+
+		specA.ImportDataMappings["d"] = lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }"))
+		specB.ImportDataMappings["d"] = lsv1alpha1.NewAnyJSON([]byte("{ \"keyB\": \"val\", \"keyA\": \"val\" }"))
+
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeTrue())
+	})
+
+	It("should correctly test inequality of different specs with import data mappings", func() {
+		specA := createDummyInstallationSpec()
+		specB := createDummyInstallationSpec()
+
+		specA.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+		}
+		specB.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyB\": \"val\", \"keyA\": \"val2\" }")),
+		}
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+		}
+		specB.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": utils.StringToAnyJSON("test"),
+		}
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+		}
+		specB.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"b": utils.StringToAnyJSON("test"),
+		}
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+		}
+		specB.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+			"b": utils.StringToAnyJSON("test"),
+		}
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+
+		specA.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+			"b": utils.StringToAnyJSON("test"),
+		}
+		specB.ImportDataMappings = map[string]lsv1alpha1.AnyJSON{
+			"a": lsv1alpha1.NewAnyJSON([]byte("{ \"keyA\": \"val\", \"keyB\": \"val\" }")),
+		}
+		Expect(instances.InstallationSpecDeepEquals(specA, specB)).To(BeFalse())
+	})
+})

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -493,7 +493,7 @@ func (c *Controller) mutateInstallation(ctx context.Context, installation *lsv1a
 		installation.Spec.ImportDataMappings[lsinstallation.AuditPolicyImportName] = lsv1alpha1.NewAnyJSON(auditPolicyRaw)
 	}
 
-	if !deepEqualInstallationSpec(oldInstallationSpec, installation.Spec.DeepCopy()) {
+	if !InstallationSpecDeepEquals(oldInstallationSpec, installation.Spec.DeepCopy()) {
 		// set reconcile annotation to start/update the installation
 		logger.Info("Setting reconcile operation annotation")
 		if installation.Annotations == nil {
@@ -503,88 +503,6 @@ func (c *Controller) mutateInstallation(ctx context.Context, installation *lsv1a
 	}
 
 	return nil
-}
-
-// deepEqualInstallationSpec tests whether two landscaper service installation specs are equal
-func deepEqualInstallationSpec(specA, specB *lsv1alpha1.InstallationSpec) bool {
-	landscaperConfigA := make(map[string]interface{})
-	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.LandscaperConfigImportName].RawMessage, &landscaperConfigA); err != nil {
-		return false
-	}
-	landscaperConfigB := make(map[string]interface{})
-	if err := json.Unmarshal(specB.ImportDataMappings[lsinstallation.LandscaperConfigImportName].RawMessage, &landscaperConfigB); err != nil {
-		return false
-	}
-	if !reflect.DeepEqual(landscaperConfigA, landscaperConfigB) {
-		return false
-	}
-
-	registryConfigA := make(map[string]interface{})
-	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.RegistryConfigImportName].RawMessage, &registryConfigA); err != nil {
-		return false
-	}
-	registryConfigB := make(map[string]interface{})
-	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.RegistryConfigImportName].RawMessage, &registryConfigB); err != nil {
-		return false
-	}
-	if !reflect.DeepEqual(registryConfigA, registryConfigB) {
-		return false
-	}
-
-	shootConfigA := make(map[string]interface{})
-	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.ShootConfigImportName].RawMessage, &shootConfigA); err != nil {
-		return false
-	}
-	shootConfigB := make(map[string]interface{})
-	if err := json.Unmarshal(specB.ImportDataMappings[lsinstallation.ShootConfigImportName].RawMessage, &shootConfigB); err != nil {
-		return false
-	}
-	if !reflect.DeepEqual(shootConfigA, shootConfigB) {
-		return false
-	}
-
-	sidecarConfigA := make(map[string]interface{})
-	if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.SidecarConfigImportName].RawMessage, &sidecarConfigA); err != nil {
-		return false
-	}
-	sidecarConfigB := make(map[string]interface{})
-	if err := json.Unmarshal(specB.ImportDataMappings[lsinstallation.SidecarConfigImportName].RawMessage, &sidecarConfigB); err != nil {
-		return false
-	}
-	if !reflect.DeepEqual(sidecarConfigA, sidecarConfigB) {
-		return false
-	}
-
-	_, policyExistsA := specA.ImportDataMappings[lsinstallation.AuditPolicyImportName]
-	_, policyExistsB := specB.ImportDataMappings[lsinstallation.AuditPolicyImportName]
-
-	if policyExistsA && policyExistsB {
-		auditPolicyA := make(map[string]interface{})
-		if err := json.Unmarshal(specA.ImportDataMappings[lsinstallation.AuditPolicyImportName].RawMessage, &auditPolicyA); err != nil {
-			return false
-		}
-		auditPolicyB := make(map[string]interface{})
-		if err := json.Unmarshal(specB.ImportDataMappings[lsinstallation.AuditPolicyImportName].RawMessage, &auditPolicyB); err != nil {
-			return false
-		}
-		if !reflect.DeepEqual(auditPolicyA, auditPolicyB) {
-			return false
-		}
-
-		delete(specA.ImportDataMappings, lsinstallation.AuditPolicyImportName)
-		delete(specB.ImportDataMappings, lsinstallation.AuditPolicyImportName)
-	}
-
-	delete(specA.ImportDataMappings, lsinstallation.LandscaperConfigImportName)
-	delete(specB.ImportDataMappings, lsinstallation.LandscaperConfigImportName)
-	delete(specA.ImportDataMappings, lsinstallation.RegistryConfigImportName)
-	delete(specB.ImportDataMappings, lsinstallation.RegistryConfigImportName)
-	delete(specA.ImportDataMappings, lsinstallation.ShootConfigImportName)
-	delete(specB.ImportDataMappings, lsinstallation.ShootConfigImportName)
-	delete(specA.ImportDataMappings, lsinstallation.SidecarConfigImportName)
-	delete(specB.ImportDataMappings, lsinstallation.SidecarConfigImportName)
-
-	return reflect.DeepEqual(specA, specB)
 }
 
 // handleExports tries to find the exports of the installation and update the instance status accordingly.


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous implementation of the installation spec equality check was very specific to the import data mapping fields in the installation.
This has been removed by a more generic implementation approach.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
