### PR TITLE
Check cu namespace prefix earlier

### DIFF
--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -174,15 +174,10 @@ func (c *Controller) reconcile(ctx context.Context, namespaceRegistration *lssv1
 	}
 
 	if err := c.Client().Create(ctx, namespace); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			namespaceRegistration.Status.Phase = "Completed"
-			if err := c.Client().Status().Update(ctx, namespaceRegistration); err != nil {
-				logger.Error(err, "failed updating status of namespaceregistration")
-				return reconcile.Result{}, err
-			}
+		if !apierrors.IsAlreadyExists(err) {
+			logger.Error(err, "failed creating namespace")
+			return reconcile.Result{}, err
 		}
-		logger.Error(err, "failed creating namespace")
-		return reconcile.Result{}, err
 	}
 
 	if err := c.createRoleIfNotExistOrUpdate(ctx, namespaceRegistration); err != nil {

--- a/pkg/controllers/subjectsync/controller.go
+++ b/pkg/controllers/subjectsync/controller.go
@@ -154,8 +154,9 @@ func (c *Controller) reconcile(ctx context.Context, subjectList *lssv1alpha1.Sub
 			continue
 		}
 
-		if !strings.HasPrefix(roleBinding.Namespace, CUSTOM_NS_PREFIX) && roleBinding.Namespace != LS_USER_NAMESPACE {
-			logger.Error(nil, "invalid customer namespace detected: "+roleBinding.Namespace)
+		if !(strings.HasPrefix(roleBinding.Namespace, CUSTOM_NS_PREFIX) || roleBinding.Namespace == LS_USER_NAMESPACE) {
+			logger.Info("user-role/-binding found outside of customer namespace. Reconcile skipped: " + roleBinding.Namespace)
+			continue
 		}
 
 		//remove subject list

--- a/pkg/controllers/subjectsync/reconcile_test.go
+++ b/pkg/controllers/subjectsync/reconcile_test.go
@@ -7,16 +7,15 @@ package subjectsync_test
 import (
 	"context"
 
+	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/gardener/landscaper/controller-utils/pkg/logging"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 
@@ -28,44 +27,42 @@ import (
 )
 
 var _ = Describe("Reconcile", func() {
+
+	const (
+		lsUserNamespace = subjectsync.LS_USER_NAMESPACE
+		userNamespace   = "cu-user1"
+	)
 	var (
 		op    *operation.TargetShootSidecarOperation
 		ctrl  reconcile.Reconciler
 		ctx   context.Context
-		state *envtest.State
+		state = envtest.NewState(lsUserNamespace)
 	)
 
-	BeforeEach(func() {
-		ctx = context.Background()
-		op = operation.NewTargetShootSidecarOperation(testenv.Client, envtest.LandscaperServiceScheme, testutils.DefaultTargetShootConfiguration())
-		ctrl = subjectsync.NewTestActuator(*op, logging.Discard())
-	})
-
-	AfterEach(func() {
-		defer ctx.Done()
-		if state != nil {
-			Expect(testenv.CleanupResources(ctx, state)).ToNot(HaveOccurred())
-		}
-	})
-
-	SetupNamespacesRolesAndBindings := func() (*corev1.Namespace, *corev1.Namespace) {
+	SetupNamespacesRolesAndBindings := func() {
 		// set up namespaces
-		lsUserNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "ls-user-"}}
-		userNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "user1-"}}
-		Expect(testenv.Client.Create(ctx, &lsUserNamespace)).To(Succeed())
-		Expect(testenv.Client.Create(ctx, &userNamespace)).To(Succeed())
+		if err := testenv.Client.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: lsUserNamespace}}); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				Expect(err).To(Succeed())
+			}
+		}
+		if err := testenv.Client.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: userNamespace}}); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				Expect(err).To(Succeed())
+			}
+		}
 
 		// setup up roles and role bindings
 		lsUserRole := rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subjectsync.LS_USER_ROLE_IN_NAMESPACE,
-				Namespace: lsUserNamespace.Name,
+				Namespace: lsUserNamespace,
 			},
 		}
 		lsUserRoleBinding := rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE,
-				Namespace: lsUserNamespace.Name,
+				Namespace: lsUserNamespace,
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
@@ -79,13 +76,13 @@ var _ = Describe("Reconcile", func() {
 		userRole := rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subjectsync.USER_ROLE_IN_NAMESPACE,
-				Namespace: userNamespace.Name,
+				Namespace: userNamespace,
 			},
 		}
 		userRoleBinding := rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      subjectsync.USER_ROLE_BINDING_IN_NAMESPACE,
-				Namespace: userNamespace.Name,
+				Namespace: userNamespace,
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: "rbac.authorization.k8s.io",
@@ -95,14 +92,37 @@ var _ = Describe("Reconcile", func() {
 		}
 		Expect(testenv.Client.Create(ctx, &userRole)).To(Succeed())
 		Expect(testenv.Client.Create(ctx, &userRoleBinding)).To(Succeed())
-
-		return &lsUserNamespace, &userNamespace
 	}
+
+	CleanupRolesAndBindings := func() {
+		roleBinding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: lsUserNamespace, Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE}}
+		Expect(testenv.Client.Delete(ctx, roleBinding)).To(Succeed())
+		roleBinding = &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Namespace: userNamespace, Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE}}
+		Expect(testenv.Client.Delete(ctx, roleBinding)).To(Succeed())
+
+		role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: lsUserNamespace, Name: subjectsync.LS_USER_ROLE_IN_NAMESPACE}}
+		Expect(testenv.Client.Delete(ctx, role)).To(Succeed())
+		role = &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Namespace: userNamespace, Name: subjectsync.USER_ROLE_IN_NAMESPACE}}
+		Expect(testenv.Client.Delete(ctx, role)).To(Succeed())
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		op = operation.NewTargetShootSidecarOperation(testenv.Client, envtest.LandscaperServiceScheme, testutils.DefaultTargetShootConfiguration())
+		ctrl = subjectsync.NewTestActuator(*op, logging.Discard())
+		SetupNamespacesRolesAndBindings()
+	})
+
+	AfterEach(func() {
+		defer ctx.Done()
+		if state != nil {
+			Expect(testenv.CleanupResources(ctx, state)).ToNot(HaveOccurred())
+		}
+		CleanupRolesAndBindings()
+	})
 
 	It("should sync role binding subjects to subjectlist", func() {
 		var err error
-
-		lsUserNamespace, userNamespace := SetupNamespacesRolesAndBindings()
 
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test1")
 		Expect(err).ToNot(HaveOccurred())
@@ -116,7 +136,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
 		updatedLsUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -127,7 +147,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[2].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
 		updatedUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -141,8 +161,6 @@ var _ = Describe("Reconcile", func() {
 	It("should skip unknown/erroneous subjects", func() {
 		var err error
 
-		lsUserNamespace, userNamespace := SetupNamespacesRolesAndBindings()
-
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test2")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -155,18 +173,16 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
 		updatedLsUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(0))
 
 		updatedUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(0))
 	})
 
 	It("should remove subjects if removed from the subject list", func() {
 		var err error
-
-		lsUserNamespace, userNamespace := SetupNamespacesRolesAndBindings()
 
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test1")
 		Expect(err).ToNot(HaveOccurred())
@@ -180,7 +196,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
 		updatedLsUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -191,7 +207,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[2].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
 		updatedUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -211,7 +227,7 @@ var _ = Describe("Reconcile", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(subjectlist))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(2))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -219,7 +235,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[1].Name).To(Equal("testserviceaccount"))
 		Expect(updatedLsUserRoleBinding.Subjects[1].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(2))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -237,13 +253,13 @@ var _ = Describe("Reconcile", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(subjectlist))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(1))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testserviceaccount"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(1))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testserviceaccount"))
@@ -259,17 +275,15 @@ var _ = Describe("Reconcile", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(subjectlist))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(0))
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(0))
 	})
 
 	It("should update entries on modify", func() {
 		var err error
-
-		lsUserNamespace, userNamespace := SetupNamespacesRolesAndBindings()
 
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test1")
 		Expect(err).ToNot(HaveOccurred())
@@ -283,7 +297,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
 		updatedLsUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -294,7 +308,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[2].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
 		updatedUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -321,7 +335,7 @@ var _ = Describe("Reconcile", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(subjectlist))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("Group"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuserMODIFIEDToGroup"))
@@ -331,7 +345,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[2].Name).To(Equal("testserviceaccountmodified"))
 		Expect(updatedLsUserRoleBinding.Subjects[2].Namespace).To(Equal("ls-user-mod"))
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("Group"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuserMODIFIEDToGroup"))
@@ -346,8 +360,6 @@ var _ = Describe("Reconcile", func() {
 	It("should empty role bindings subjects if subjectlist is emptied", func() {
 		var err error
 
-		lsUserNamespace, userNamespace := SetupNamespacesRolesAndBindings()
-
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test1")
 		Expect(err).ToNot(HaveOccurred())
 
@@ -360,7 +372,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
 		updatedLsUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedLsUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -371,7 +383,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedLsUserRoleBinding.Subjects[2].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
 
 		updatedUserRoleBinding := rbacv1.RoleBinding{}
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(3))
 		Expect(updatedUserRoleBinding.Subjects[0].Kind).To(Equal("User"))
 		Expect(updatedUserRoleBinding.Subjects[0].Name).To(Equal("testuser"))
@@ -390,10 +402,10 @@ var _ = Describe("Reconcile", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(subjectlist))
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(subjectlist), subjectlist)).To(Succeed())
 
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace.Name}, &updatedLsUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.LS_USER_ROLE_BINDING_IN_NAMESPACE, Namespace: lsUserNamespace}, &updatedLsUserRoleBinding)).To(Succeed())
 
 		Expect(len(updatedLsUserRoleBinding.Subjects)).To(Equal(0))
-		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace.Name}, &updatedUserRoleBinding)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_ROLE_BINDING_IN_NAMESPACE, Namespace: userNamespace}, &updatedUserRoleBinding)).To(Succeed())
 		Expect(len(updatedUserRoleBinding.Subjects)).To(Equal(0))
 	})
 })

--- a/pkg/controllers/subjectsync/testdata/reconcile/test1/subjectlist.yaml
+++ b/pkg/controllers/subjectsync/testdata/reconcile/test1/subjectlist.yaml
@@ -2,7 +2,7 @@ apiVersion: landscaper-service.gardener.cloud/v1alpha1
 kind: SubjectList
 metadata:
   name: subjectlist
-  namespace: {{ .Namespace }}
+  namespace: ls-user
 spec:
   subjects:
   - kind: User

--- a/pkg/controllers/subjectsync/testdata/reconcile/test2/subjectlist.yaml
+++ b/pkg/controllers/subjectsync/testdata/reconcile/test2/subjectlist.yaml
@@ -2,7 +2,7 @@ apiVersion: landscaper-service.gardener.cloud/v1alpha1
 kind: SubjectList
 metadata:
   name: subjectlist
-  namespace: {{ .Namespace }}
+  namespace: ls-user
 spec:
   subjects:
   - kind: UserUnknownKind

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -194,6 +194,16 @@ func (e *Environment) CleanupResources(ctx context.Context, state *State) error 
 			return err
 		}
 	}
+	for _, obj := range state.NamespaceRegistrations {
+		if err := e.deleteObject(ctx, obj); err != nil {
+			return err
+		}
+	}
+	for _, obj := range state.SubjectLists {
+		if err := e.deleteObject(ctx, obj); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/test/utils/envtest/state.go
+++ b/test/utils/envtest/state.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/gardener/landscaper-service/pkg/controllers/subjectsync"
+
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 )
 
@@ -124,13 +126,8 @@ func (s *State) GetNamespaceRegistration(name string) *lssv1alpha1.NamespaceRegi
 }
 
 // GetSubjectListInNamespace retrieves a SubjectList by the given name in the given namespace
-func (s *State) GetSubjectListInNamespace(name string, namespace string) *lssv1alpha1.SubjectList {
-	return s.SubjectLists[namespace+"/"+name]
-}
-
-// GetSubjectListInNamespace retrieves a SubjectList by the given name in the given namespace
 func (s *State) GetSubjectList(name string) *lssv1alpha1.SubjectList {
-	return s.SubjectLists[s.Namespace+"/"+name]
+	return s.SubjectLists[subjectsync.LS_USER_NAMESPACE+"/"+name]
 }
 
 // AddObject adds a client.Object to the state.


### PR DESCRIPTION
**What this PR does / why we need it**:

With this PR the customer namespace prefix will be checked directly at the beginning of the reconcile of the NamespaceRegistration controller.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
