### PR TITLE
only cleanup shoots and configmaps that belong to the corresponding test type

### DIFF
--- a/hack/integration-test.py
+++ b/hack/integration-test.py
@@ -15,6 +15,7 @@ import oci.auth as oa
 from util import ctx
 from subprocess import run
 
+test_purpose = os.environ["TEST_PURPOSE"]
 project_root = os.environ["PROJECT_ROOT"]
 test_cluster = os.environ["TEST_CLUSTER"]
 hosting_cluster = os.environ["HOSTING_CLUSTER"]
@@ -63,6 +64,7 @@ with (
     registry_secrets_path = registry_temp_file.switch()
 
     command = ["go", "run", "./pkg/main.go",
+                "--test-purpose", test_purpose,
                 "--kubeconfig", test_cluster_kubeconfig_path,
                 "--hosting-kubeconfig", hosting_cluster_kubeconfig_path,
                 "--gardener-service-account-kubeconfig", gardener_cluster_kubeconfig_path,

--- a/hack/integration-test.sh
+++ b/hack/integration-test.sh
@@ -13,9 +13,11 @@ ARG=$1
 if [[ $ARG == "pull-request" ]]; then
   TEST_CLUSTER="laas-integration-test-pr"
   HOSTING_CLUSTER="laas-integration-test-target-pr"
+  export TEST_PURPOSE="pull-request"
 else
   TEST_CLUSTER="laas-integration-test"
   HOSTING_CLUSTER="laas-integration-test-target"
+  export TEST_PURPOSE="head-update-release"
 fi
 
 GARDENER_CLUSTER="laas-integration-test-service-account"

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -387,7 +387,7 @@ func cleanupResources(ctx context.Context, hostingClient, laasClient client.Clie
 		return err
 	}
 
-	if err := util.DeleteTestShootClusters(ctx, config.GardenerServiceAccountKubeconfig, config.GardenerProject, test.Scheme()); err != nil {
+	if err := util.DeleteTestShootClusters(ctx, config.GardenerServiceAccountKubeconfig, config.GardenerProject, config.TestPurpose, test.Scheme()); err != nil {
 		return err
 	}
 	return nil

--- a/integration-test/pkg/test/test_config.go
+++ b/integration-test/pkg/test/test_config.go
@@ -38,6 +38,7 @@ func init() {
 
 // TestConfig contains all the configured flags of the integration test.
 type TestConfig struct {
+	TestPurpose                      string
 	TestClusterKubeconfig            string
 	HostingClusterKubeconfig         string
 	GardenerServiceAccountKubeconfig string
@@ -58,6 +59,7 @@ type TestConfig struct {
 // ParseConfig parses the TestConfig from the command line arguments.
 func ParseConfig() *TestConfig {
 	var (
+		testPurpose,
 		testClusterKubeconfig,
 		hostingClusterKubeconfig,
 		gardenerServiceAccountKubeconfig,
@@ -68,6 +70,7 @@ func ParseConfig() *TestConfig {
 		maxRetries int
 	)
 
+	flag.StringVar(&testPurpose, "test-purpose", "", "set an optional test purpose")
 	flag.StringVar(&testClusterKubeconfig, "kubeconfig", "", "path to the kubeconfig of the cluster")
 	flag.StringVar(&hostingClusterKubeconfig, "hosting-kubeconfig", "", "path to the kubeconfig of the hosting cluster")
 	flag.StringVar(&gardenerServiceAccountKubeconfig, "gardener-service-account-kubeconfig", "", "path to the kubeconfig of the hosting cluster")
@@ -86,6 +89,7 @@ func ParseConfig() *TestConfig {
 	}
 
 	return &TestConfig{
+		TestPurpose:                      testPurpose,
 		TestClusterKubeconfig:            testClusterKubeconfig,
 		HostingClusterKubeconfig:         hostingClusterKubeconfig,
 		GardenerServiceAccountKubeconfig: gardenerServiceAccountKubeconfig,

--- a/integration-test/pkg/tests/test_create_deployment.go
+++ b/integration-test/pkg/tests/test_create_deployment.go
@@ -81,6 +81,10 @@ func (r *CreateDeploymentRunner) createDeployment() error {
 		},
 	}
 
+	if len(r.config.TestPurpose) > 0 {
+		deployment.Name = fmt.Sprintf("test-%s", r.config.TestPurpose)
+	}
+
 	if err := r.clusterClients.TestCluster.Create(r.ctx, deployment); err != nil {
 		return fmt.Errorf("failed to create deployment: %w", err)
 	}

--- a/integration-test/pkg/util/util.go
+++ b/integration-test/pkg/util/util.go
@@ -562,6 +562,7 @@ func DeleteTestShootClusters(ctx context.Context, gardenerServiceAccountKubeconf
 	}
 
 	for _, shoot := range shootList.Items {
+		logger.Info("found shoot", lc.KeyResource, shoot.GetName())
 		labels := shoot.GetLabels()
 		instanceName, ok := labels[lssv1alpha1.ShootInstanceNameLabel]
 		logger.Info("ignoring shoot without instance name label")
@@ -605,6 +606,7 @@ func DeleteTestShootClusters(ctx context.Context, gardenerServiceAccountKubeconf
 	}
 
 	for _, configMap := range configMapList.Items {
+		logger.Info("found config map", lc.KeyResource, configMap.GetName())
 		labels := configMap.GetLabels()
 		instanceName, ok := labels[lssv1alpha1.ShootInstanceNameLabel]
 		logger.Info("ignoring config map without instance name label")
@@ -624,6 +626,7 @@ func DeleteTestShootClusters(ctx context.Context, gardenerServiceAccountKubeconf
 			continue
 		}
 
+		logger.Info("deleting config map", lc.KeyResource, configMap.GetName())
 		if err := saClient.Delete(ctx, &configMap); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return fmt.Errorf("failed to delete config map %q: %w", configMap.GetName(), err)

--- a/integration-test/pkg/util/util.go
+++ b/integration-test/pkg/util/util.go
@@ -565,8 +565,8 @@ func DeleteTestShootClusters(ctx context.Context, gardenerServiceAccountKubeconf
 		logger.Info("found shoot", lc.KeyResource, shoot.GetName())
 		labels := shoot.GetLabels()
 		instanceName, ok := labels[lssv1alpha1.ShootInstanceNameLabel]
-		logger.Info("ignoring shoot without instance name label")
 		if !ok {
+			logger.Info("ignoring shoot without instance name label")
 			continue
 		}
 
@@ -609,8 +609,8 @@ func DeleteTestShootClusters(ctx context.Context, gardenerServiceAccountKubeconf
 		logger.Info("found config map", lc.KeyResource, configMap.GetName())
 		labels := configMap.GetLabels()
 		instanceName, ok := labels[lssv1alpha1.ShootInstanceNameLabel]
-		logger.Info("ignoring config map without instance name label")
 		if !ok {
+			logger.Info("ignoring config map without instance name label")
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In pull request integration tests, only cleanup shoots that have been created for pull request test jobs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
