### PR TITLE
Non-Static Kubeconfigs

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/installation/blueprint.yaml
+++ b/.landscaper/landscaper-instance/blueprint/installation/blueprint.yaml
@@ -100,6 +100,13 @@ imports:
         The configuration for the sidecar server containing the namespace registration and subject sync controller.
       $ref: "cd://resources/sidecar-config-definition"
 
+  - name: rotationConfig
+    type: data
+    schema:
+      description: |
+        The configuration for the rotation of credentials.
+      $ref: "cd://resources/rotation-config-definition"
+
 exports:
   - name: landscaperClusterEndpoint
     type: data

--- a/.landscaper/landscaper-instance/blueprint/installation/landscaper-rbac-subinst.yaml
+++ b/.landscaper/landscaper-instance/blueprint/installation/landscaper-rbac-subinst.yaml
@@ -17,6 +17,8 @@ imports:
       dataRef: shootClusterEndpoint
     - name: shootConfig
       dataRef: shootConfig
+    - name: rotationConfig
+      dataRef: rotationConfig
 
 exports:
   data:

--- a/.landscaper/landscaper-instance/blueprint/installation/shoot-cluster-subinst.yaml
+++ b/.landscaper/landscaper-instance/blueprint/installation/shoot-cluster-subinst.yaml
@@ -26,6 +26,8 @@ imports:
       dataRef: auditPolicy
     - name: subaccountId
       dataRef: subaccountId
+    - name: rotationConfig
+      dataRef: rotationConfig
 
 exports:
   targets:

--- a/.landscaper/landscaper-instance/blueprint/installation/sidecar-rbac-subinst.yaml
+++ b/.landscaper/landscaper-instance/blueprint/installation/sidecar-rbac-subinst.yaml
@@ -15,6 +15,8 @@ imports:
       dataRef: targetClusterNamespace
     - name: shootClusterEndpoint
       dataRef: shootClusterEndpoint
+    - name: rotationConfig
+      dataRef: rotationConfig
 
 exports:
   data:

--- a/.landscaper/landscaper-instance/blueprint/rbac/blueprint.yaml
+++ b/.landscaper/landscaper-instance/blueprint/rbac/blueprint.yaml
@@ -25,6 +25,13 @@ imports:
         The "shootConfig" Specifies the gardener shoot configuration.
       $ref: "cd://resources/shoot-config-definition"
 
+  - name: rotationConfig
+    type: data
+    schema:
+      description: |
+        The configuration for the rotation of credentials.
+      $ref: "cd://resources/rotation-config-definition"
+
 exports:
   - name: landscaperControllerKubeconfigYaml
     type: data

--- a/.landscaper/landscaper-instance/blueprint/rbac/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/rbac/deploy-execution.yaml
@@ -37,42 +37,6 @@ deployItems:
       exports:
         defaultTimeout: 10m
         exports:
-        - key: landscaperControllerToken
-          timeout: 10m
-          jsonPath: ".data.token"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-controller-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
-        - key: landscaperControllerCaCrt
-          timeout: 10m
-          jsonPath: ".data.ca\\.crt"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-controller-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
-        - key: landscaperWebhooksToken
-          timeout: 10m
-          jsonPath: ".data.token"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-webhooks-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
-        - key: landscaperWebhooksCaCrt
-          timeout: 10m
-          jsonPath: ".data.ca\\.crt"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-webhooks-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
         - key: landscaperUserToken
           timeout: 10m
           jsonPath: ".data.token"

--- a/.landscaper/landscaper-instance/blueprint/rbac/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/rbac/deploy-execution.yaml
@@ -33,24 +33,3 @@ deployItems:
               create: true
               annotations: {}
               name: landscaper-user
-
-      exports:
-        defaultTimeout: 10m
-        exports:
-        - key: landscaperUserToken
-          timeout: 10m
-          jsonPath: ".data.token"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-user-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
-        - key: landscaperUserCaCrt
-          timeout: 10m
-          jsonPath: ".data.ca\\.crt"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: landscaper-user-token
-            namespace: {{ .imports.targetClusterNamespace }}

--- a/.landscaper/landscaper-instance/blueprint/rbac/export-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/rbac/export-execution.yaml
@@ -1,69 +1,9 @@
 exports:
   landscaperControllerKubeconfigYaml: |
-    apiVersion: v1
-    kind: Config
-    current-context: landscaper-cluster
-    contexts:
-    - name: landscaper-cluster
-      context:
-        cluster: landscaper-cluster
-        user: landscaper-controller
-    clusters:
-    - name: landscaper-cluster
-      cluster:
-        certificate-authority-data: {{ index .values "deployitems" "landscaper-rbac" "landscaperControllerCaCrt" }}
-        server: {{ index .values "dataobjects" "shootClusterEndpoint" }}:443
-    users:
-    - name: landscaper-controller
-      user:
-        token: {{ index .values "deployitems" "landscaper-rbac" "landscaperControllerToken" | b64dec }}
+    {{- getServiceAccountKubeconfig "landscaper-controller" .imports.targetClusterNamespace .imports.rotationConfig.tokenExpirationSeconds .imports.shootCluster | b64dec | nindent 4 }}
 
   landscaperWebhooksKubeconfigYaml: |
-    apiVersion: v1
-    kind: Config
-    current-context: landscaper-cluster
-    contexts:
-    - name: landscaper-cluster
-      context:
-        cluster: landscaper-cluster
-        user: landscaper-webhooks
-    clusters:
-    - name: landscaper-cluster
-      cluster:
-        certificate-authority-data: {{ index .values "deployitems" "landscaper-rbac" "landscaperWebhooksCaCrt" }}
-        server: {{ index .values "dataobjects" "shootClusterEndpoint" }}:443
-    users:
-    - name: landscaper-webhooks
-      user:
-        token: {{ index .values "deployitems" "landscaper-rbac" "landscaperWebhooksToken" | b64dec }}
+    {{- getServiceAccountKubeconfig "landscaper-webhooks" .imports.targetClusterNamespace .imports.rotationConfig.tokenExpirationSeconds .imports.shootCluster | b64dec | nindent 4 }}
 
   landscaperUserKubeconfigYaml: |
-    apiVersion: v1
-    kind: Config
-    current-context: landscaper-cluster
-    contexts:
-    - name: landscaper-cluster
-      context:
-        cluster: landscaper-cluster
-        user: landscaper-user
-    clusters:
-    - name: landscaper-cluster
-      cluster:
-        certificate-authority-data: {{ index .values "deployitems" "landscaper-rbac" "landscaperUserCaCrt" }}
-        server: {{ index .values "dataobjects" "shootClusterEndpoint" }}:443
-    users:
-    - name: landscaper-user
-      user:
-        exec:
-          apiVersion: client.authentication.k8s.io/v1beta1
-          command: kubectl
-          args:
-            - oidc-login
-            - get-token
-            - '--oidc-issuer-url={{ .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.issuerURL }}'
-            - '--oidc-client-id={{ .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.clientID }}'
-            - '--oidc-extra-scope=email'
-            - '--oidc-extra-scope=profile'
-            - '--oidc-extra-scope=offline_access'
-            - '--oidc-use-pkce'
-            - '--grant-type=auto'
+    {{- getOidcKubeconfig .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.issuerURL .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.clientID .imports.shootCluster | b64dec | nindent 4 }}

--- a/.landscaper/landscaper-instance/blueprint/shoot/blueprint.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/blueprint.yaml
@@ -48,6 +48,13 @@ imports:
     schema:
       type: string
 
+  - name: rotationConfig
+    type: data
+    schema:
+      description: |
+        The configuration for the rotation of credentials.
+      $ref: "cd://resources/rotation-config-definition"
+
 exports:
   - name: shootClusterKubeconfig
     type: data

--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -116,7 +116,7 @@ deployItems:
               secretBindingName: {{ .imports.secretBindingName }}
               kubernetes:
                 version: {{ .imports.shootConfig.kubernetes.version }}
-                enableStaticTokenKubeconfig: true
+                enableStaticTokenKubeconfig: false
                 kubeAPIServer:
                   {{ if ((.imports.shootConfig.kubernetes.kubeAPIServer).oidcConfig) }}
                   oidcConfig:
@@ -140,13 +140,6 @@ deployItems:
       exports:
         defaultTimeout: 30m
         exports:
-          - key: shootClusterKubeconfig
-            jsonPath: .data.kubeconfig
-            fromResource:
-              apiVersion: v1
-              kind: Secret
-              name: {{ .imports.name }}.kubeconfig
-              namespace: {{ .imports.namespace }}
           - key: shootClusterEndpoint
             jsonPath: .status.advertisedAddresses[?(@.name == 'external')].url
             fromResource:

--- a/.landscaper/landscaper-instance/blueprint/shoot/export-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/export-execution.yaml
@@ -1,9 +1,10 @@
 exports:
   shootClusterEndpoint: {{  index .values "deployitems" "shoot-cluster" "shootClusterEndpoint"  }}
+  {{- $shootAdminKubeconfig := getShootAdminKubeconfig .imports.name .imports.namespace .imports.rotationConfig.adminKubeconfigExpirationSeconds .imports.gardenerServiceAccount | b64dec }}
   shootClusterKubeconfig: |
-    {{- index .values "deployitems" "shoot-cluster" "shootClusterKubeconfig" | b64dec | nindent 4 }}
+    {{- nindent 4 $shootAdminKubeconfig }}
   shootCluster:
     type: landscaper.gardener.cloud/kubernetes-cluster
     config:
       kubeconfig: |
-        {{- index .values "deployitems" "shoot-cluster" "shootClusterKubeconfig" | b64dec | nindent 8 }}
+        {{- nindent 8 $shootAdminKubeconfig }}

--- a/.landscaper/landscaper-instance/blueprint/sidecar-rbac/blueprint.yaml
+++ b/.landscaper/landscaper-instance/blueprint/sidecar-rbac/blueprint.yaml
@@ -18,6 +18,13 @@ imports:
     schema:
       type: string
 
+  - name: rotationConfig
+    type: data
+    schema:
+      description: |
+        The configuration for the rotation of credentials.
+      $ref: "cd://resources/rotation-config-definition"
+
 exports:
   - name: sidecarControllerKubeconfigYaml
     type: data

--- a/.landscaper/landscaper-instance/blueprint/sidecar-rbac/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/sidecar-rbac/deploy-execution.yaml
@@ -18,25 +18,4 @@ deployItems:
       values:
         serviceAccount:
           annotations: { }
-          name: sidecar-rbac
-
-      exports:
-        defaultTimeout: 10m
-        exports:
-        - key: rbacSidecarToken
-          timeout: 10m
-          jsonPath: ".data.token"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: sidecar-token
-            namespace: {{ .imports.targetClusterNamespace }}
-
-        - key: rbacSidecarCaCrt
-          timeout: 10m
-          jsonPath: ".data.ca\\.crt"
-          fromResource:
-            apiVersion: v1
-            kind: Secret
-            name: sidecar-token
-            namespace: {{ .imports.targetClusterNamespace }}
+          name: sidecar

--- a/.landscaper/landscaper-instance/blueprint/sidecar-rbac/export-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/sidecar-rbac/export-execution.yaml
@@ -1,20 +1,3 @@
 exports:
   sidecarControllerKubeconfigYaml: |
-    apiVersion: v1
-    kind: Config
-    current-context: landscaper-cluster
-    contexts:
-    - name: landscaper-cluster
-      context:
-        cluster: landscaper-cluster
-        user: sidecar-controller
-    clusters:
-    - name: landscaper-cluster
-      cluster:
-        certificate-authority-data: {{ index .values "deployitems" "sidecar-rbac" "rbacSidecarCaCrt" }}
-        server: {{ index .values "dataobjects" "shootClusterEndpoint" }}:443
-    users:
-    - name: sidecar-controller
-      user:
-        token: {{ index .values "deployitems" "sidecar-rbac" "rbacSidecarToken" | b64dec }}
-
+    {{- getServiceAccountKubeconfig "sidecar" .imports.targetClusterNamespace .imports.rotationConfig.tokenExpirationSeconds .imports.shootCluster | b64dec | nindent 4 }}

--- a/.landscaper/landscaper-instance/definition/rotation-configuration.json
+++ b/.landscaper/landscaper-instance/definition/rotation-configuration.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "github.com/gardener/landscaper-service/landscaper-instance/definitions/rotation-configuration",
+  "title": "Rotation Configuration",
+  "description": "Describes the configuration for the rotation of credentials.",
+  "type": "object",
+  "properties": {
+    "tokenExpirationSeconds": {
+      "type:": "integer",
+      "format": "int32"
+    },
+    "adminKubeconfigExpirationSeconds": {
+      "type:": "integer",
+      "format": "int32"
+    }
+  }
+}

--- a/.landscaper/landscaper-instance/resources.yaml
+++ b/.landscaper/landscaper-instance/resources.yaml
@@ -118,4 +118,13 @@ input:
   path: ./definition/sidecar-configuration.json
   mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
 ...
+---
+type: landscaper.gardener.cloud/jsonschema
+name: rotation-config-definition
+relation: local
+input:
+  type: file
+  path: ./definition/rotation-configuration.json
+  mediaType: application/vnd.gardener.landscaper.jsonschema.layer.v1.json
+...
 

--- a/charts/sidecar-rbac/templates/_helpers.tpl
+++ b/charts/sidecar-rbac/templates/_helpers.tpl
@@ -25,6 +25,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Create the name of the service account to use
 */}}
 {{- define "sidecar.serviceAccountName" -}}
-{{- default "sidecar" .Values.name }}
+{{- default "sidecar" .Values.serviceAccount.name }}
 {{- end }}
 

--- a/charts/sidecar-rbac/templates/serviceaccount.yaml
+++ b/charts/sidecar-rbac/templates/serviceaccount.yaml
@@ -10,7 +10,7 @@ metadata:
   name: {{ include "sidecar.serviceAccountName" . }}
   labels:
     {{- include "sidecar.labels" . | nindent 4 }}
-  {{- with .Values.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,6 +24,6 @@ metadata:
     {{- include "sidecar.labels" . | nindent 4 }}
   annotations:
     kubernetes.io/service-account.name: {{ include "sidecar.serviceAccountName" . }}
-    {{- with .Values.annotations }}
+    {{- with .Values.serviceAccount.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/integration-test/pkg/tests/test_verify_deployment.go
+++ b/integration-test/pkg/tests/test_verify_deployment.go
@@ -222,10 +222,14 @@ func (r *VerifyDeploymentRunner) verifyOIDCKubeconfig(instance *lssv1alpha1.Inst
 		return fmt.Errorf("failed to load kubeconfig: %w", err)
 	}
 
-	if _, ok := clientCfg.AuthInfos["landscaper-user"]; !ok {
-		return fmt.Errorf("failed to load user landscaper-user in user kubeconfig")
+	context, ok := clientCfg.Contexts[clientCfg.CurrentContext]
+	if !ok {
+		return fmt.Errorf("current context is missing in user kubeconfig")
 	}
-	authInfo := clientCfg.AuthInfos["landscaper-user"]
+	authInfo, ok := clientCfg.AuthInfos[context.AuthInfo]
+	if !ok {
+		return fmt.Errorf("failed to load user of current context in user kubeconfig")
+	}
 	if authInfo.Exec.APIVersion != "client.authentication.k8s.io/v1beta1" {
 		return fmt.Errorf("apiversion in user kubeconfig authinfo incorrect")
 	}

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/installation/installation.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/installation/installation.go
@@ -40,6 +40,8 @@ const (
 	LandscaperConfigImportName = "landscaperConfig"
 	// SidecarConfigImportName is the import for the sidecar configuration.
 	SidecarConfigImportName = "sidecarConfig"
+	// RotationConfigImportName is the import for the rotation configuration.
+	RotationConfigImportName = "rotationConfig"
 	// ShootNameImportName is the import for the shoot name.
 	ShootNameImportName = "shootName"
 	// ShootNamespaceImportName is the import for the shoot namespace.
@@ -98,12 +100,7 @@ func NewRegistryConfig() *RegistryConfig {
 
 // ToAnyJSON marshals this registry configuration to an AnyJSON object.
 func (r *RegistryConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(r)
-	if err != nil {
-		return nil, err
-	}
-	anyJSON := lsv1alpha1.NewAnyJSON(raw)
-	return &anyJSON, err
+	return toAnyJSON(r)
 }
 
 // Landscaper specifies the landscaper controller configuration.
@@ -153,12 +150,7 @@ func NewLandscaperConfig() *LandscaperConfig {
 
 // ToAnyJSON marshals this landscaper configuration to an AnyJSON object.
 func (l *LandscaperConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(l)
-	if err != nil {
-		return nil, err
-	}
-	anyJSON := lsv1alpha1.NewAnyJSON(raw)
-	return &anyJSON, err
+	return toAnyJSON(l)
 }
 
 // SidecarConfig specifies the config for the namespace registration and subject sync controller.
@@ -177,7 +169,34 @@ func NewSidecarConfig() *SidecarConfig {
 
 // ToAnyJSON marshals this SidecarConfig to an AnyJSON object.
 func (l *SidecarConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(l)
+	return toAnyJSON(l)
+}
+
+// RotationConfig specifies the config for the rotation of credentials.
+type RotationConfig struct {
+	// TokenExpirationSeconds defines how long the tokens are valid	which the landscaper and sidecar controllers use
+	// to access the resource cluster, e.g. for watching installations, namespace registrations etc.
+	TokenExpirationSeconds int64 `json:"tokenExpirationSeconds,omitempty"`
+	// AdminKubeconfigExpirationSeconds defines how long the admin kubeconfig for a resource cluster is valid.
+	// The kubeconfig is used to deploy RBAC objects on the resource cluster.
+	AdminKubeconfigExpirationSeconds int64 `json:"adminKubeconfigExpirationSeconds,omitempty"`
+}
+
+// NewRotationConfig creates a new RotationConfig.
+func NewRotationConfig(tokenExpirationSeconds, adminKubeconfigExpirationSeconds int64) *RotationConfig {
+	return &RotationConfig{
+		TokenExpirationSeconds:           tokenExpirationSeconds,
+		AdminKubeconfigExpirationSeconds: adminKubeconfigExpirationSeconds,
+	}
+}
+
+// ToAnyJSON marshals this RotationConfig to an AnyJSON object.
+func (r *RotationConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
+	return toAnyJSON(r)
+}
+
+func toAnyJSON(obj any) (*lsv1alpha1.AnyJSON, error) {
+	raw, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/apis/installation/installation.go
+++ b/pkg/apis/installation/installation.go
@@ -40,6 +40,8 @@ const (
 	LandscaperConfigImportName = "landscaperConfig"
 	// SidecarConfigImportName is the import for the sidecar configuration.
 	SidecarConfigImportName = "sidecarConfig"
+	// RotationConfigImportName is the import for the rotation configuration.
+	RotationConfigImportName = "rotationConfig"
 	// ShootNameImportName is the import for the shoot name.
 	ShootNameImportName = "shootName"
 	// ShootNamespaceImportName is the import for the shoot namespace.
@@ -98,12 +100,7 @@ func NewRegistryConfig() *RegistryConfig {
 
 // ToAnyJSON marshals this registry configuration to an AnyJSON object.
 func (r *RegistryConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(r)
-	if err != nil {
-		return nil, err
-	}
-	anyJSON := lsv1alpha1.NewAnyJSON(raw)
-	return &anyJSON, err
+	return toAnyJSON(r)
 }
 
 // Landscaper specifies the landscaper controller configuration.
@@ -153,12 +150,7 @@ func NewLandscaperConfig() *LandscaperConfig {
 
 // ToAnyJSON marshals this landscaper configuration to an AnyJSON object.
 func (l *LandscaperConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(l)
-	if err != nil {
-		return nil, err
-	}
-	anyJSON := lsv1alpha1.NewAnyJSON(raw)
-	return &anyJSON, err
+	return toAnyJSON(l)
 }
 
 // SidecarConfig specifies the config for the namespace registration and subject sync controller.
@@ -177,7 +169,34 @@ func NewSidecarConfig() *SidecarConfig {
 
 // ToAnyJSON marshals this SidecarConfig to an AnyJSON object.
 func (l *SidecarConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
-	raw, err := json.Marshal(l)
+	return toAnyJSON(l)
+}
+
+// RotationConfig specifies the config for the rotation of credentials.
+type RotationConfig struct {
+	// TokenExpirationSeconds defines how long the tokens are valid	which the landscaper and sidecar controllers use
+	// to access the resource cluster, e.g. for watching installations, namespace registrations etc.
+	TokenExpirationSeconds int64 `json:"tokenExpirationSeconds,omitempty"`
+	// AdminKubeconfigExpirationSeconds defines how long the admin kubeconfig for a resource cluster is valid.
+	// The kubeconfig is used to deploy RBAC objects on the resource cluster.
+	AdminKubeconfigExpirationSeconds int64 `json:"adminKubeconfigExpirationSeconds,omitempty"`
+}
+
+// NewRotationConfig creates a new RotationConfig.
+func NewRotationConfig(tokenExpirationSeconds, adminKubeconfigExpirationSeconds int64) *RotationConfig {
+	return &RotationConfig{
+		TokenExpirationSeconds:           tokenExpirationSeconds,
+		AdminKubeconfigExpirationSeconds: adminKubeconfigExpirationSeconds,
+	}
+}
+
+// ToAnyJSON marshals this RotationConfig to an AnyJSON object.
+func (r *RotationConfig) ToAnyJSON() (*lsv1alpha1.AnyJSON, error) {
+	return toAnyJSON(r)
+}
+
+func toAnyJSON(obj any) (*lsv1alpha1.AnyJSON, error) {
+	raw, err := json.Marshal(obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

During the deployment of a landscaper instance, we create (among other things) kubeconfigs to access the resource cluster. These have been [static token kubeconfigs](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md#static-token-kubeconfig), and this is changed in this pull request.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
