### PR TITLE
Update landscaper version to v0.48.0

### DIFF
--- a/.landscaper/landscaper-instance/component-references.yaml
+++ b/.landscaper/landscaper-instance/component-references.yaml
@@ -1,5 +1,5 @@
 ---
 componentName: github.com/gardener/landscaper
 name: landscaper
-version: v0.47.0
+version: v0.48.0
 ...

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.66
-	github.com/gardener/landscaper/apis v0.47.0
-	github.com/gardener/landscaper/controller-utils v0.47.0
+	github.com/gardener/landscaper/apis v0.48.0
+	github.com/gardener/landscaper/controller-utils v0.48.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.1.2
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -99,10 +99,10 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/component-spec/bindings-go v0.0.66 h1:FvtnnTxXJi2ZCC/GgijUNJCcwwdlZAiEWpZTtyHviz0=
 github.com/gardener/component-spec/bindings-go v0.0.66/go.mod h1:qr7kADDXbXB0huul+ih/B43YkwyiMFYQepp/tqJ331c=
-github.com/gardener/landscaper/apis v0.47.0 h1:eUUEle3Ult+PU49v8nVioHGScW+5Trb1DZnbkBKSVIA=
-github.com/gardener/landscaper/apis v0.47.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
-github.com/gardener/landscaper/controller-utils v0.47.0 h1:hMno7fcxB9NZLxMgcz1fZDiuKCgmupAW5bKpTgyd4qw=
-github.com/gardener/landscaper/controller-utils v0.47.0/go.mod h1:crx7hASFdII9ae4ud2+KfdnCUXi+tuHO3PdiXiveF6c=
+github.com/gardener/landscaper/apis v0.48.0 h1:o7PwJNp7zVcdS1XN/szsA561O6PiGF0hPeShwMVXlLU=
+github.com/gardener/landscaper/apis v0.48.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
+github.com/gardener/landscaper/controller-utils v0.48.0 h1:iQHt0nxSpUACO+GpPGHVL/OLaTR+drgCcbenK1P3Ffc=
+github.com/gardener/landscaper/controller-utils v0.48.0/go.mod h1:yqJwKyXKU3Qt8EGsw5ngQg6723g2WFkvLcf/AEyRXAk=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/integration-test/go.mod
+++ b/integration-test/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.66
 	github.com/gardener/landscaper-service v0.0.0-00010101000000-000000000000
-	github.com/gardener/landscaper/apis v0.47.0
-	github.com/gardener/landscaper/controller-utils v0.47.0
+	github.com/gardener/landscaper/apis v0.48.0
+	github.com/gardener/landscaper/controller-utils v0.48.0
 	github.com/gardener/landscapercli v0.20.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1

--- a/integration-test/go.sum
+++ b/integration-test/go.sum
@@ -197,10 +197,10 @@ github.com/gardener/component-spec/bindings-go v0.0.66/go.mod h1:qr7kADDXbXB0huu
 github.com/gardener/image-vector v0.10.0 h1:Ysg3hxfiGUG/doajiZ0nQuUaJYwfO5BZCOcijL3tRuo=
 github.com/gardener/landscaper v0.40.0 h1:s5kInFvUvh8kTheBwbpTfQGKCZpGRFvQXjyoh8IKcLQ=
 github.com/gardener/landscaper v0.40.0/go.mod h1:1e7x2Dk/nD4gBSx7S0xbvLNjKIPww/tkCLFJVxalB3U=
-github.com/gardener/landscaper/apis v0.47.0 h1:eUUEle3Ult+PU49v8nVioHGScW+5Trb1DZnbkBKSVIA=
-github.com/gardener/landscaper/apis v0.47.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
-github.com/gardener/landscaper/controller-utils v0.47.0 h1:hMno7fcxB9NZLxMgcz1fZDiuKCgmupAW5bKpTgyd4qw=
-github.com/gardener/landscaper/controller-utils v0.47.0/go.mod h1:crx7hASFdII9ae4ud2+KfdnCUXi+tuHO3PdiXiveF6c=
+github.com/gardener/landscaper/apis v0.48.0 h1:o7PwJNp7zVcdS1XN/szsA561O6PiGF0hPeShwMVXlLU=
+github.com/gardener/landscaper/apis v0.48.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
+github.com/gardener/landscaper/controller-utils v0.48.0 h1:iQHt0nxSpUACO+GpPGHVL/OLaTR+drgCcbenK1P3Ffc=
+github.com/gardener/landscaper/controller-utils v0.48.0/go.mod h1:yqJwKyXKU3Qt8EGsw5ngQg6723g2WFkvLcf/AEyRXAk=
 github.com/gardener/landscapercli v0.20.0 h1:R2aXuWBn1oA/Dn0rm0+kbcb7A+1Dzxv57DFbP3nRXHc=
 github.com/gardener/landscapercli v0.20.0/go.mod h1:jNHEtM+i4/LyTB39CRbJxuFDNcdMuSElB3HTh76k230=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/integration-test/vendor/modules.txt
+++ b/integration-test/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/gardener/landscaper-service/pkg/apis/core
 github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1
 github.com/gardener/landscaper-service/pkg/apis/installation
 github.com/gardener/landscaper-service/pkg/utils
-# github.com/gardener/landscaper/apis v0.47.0
+# github.com/gardener/landscaper/apis v0.48.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/config/install
@@ -115,7 +115,7 @@ github.com/gardener/landscaper/apis/deployer/utils/readinesschecks
 github.com/gardener/landscaper/apis/errors
 github.com/gardener/landscaper/apis/mediatype
 github.com/gardener/landscaper/apis/schema
-# github.com/gardener/landscaper/controller-utils v0.47.0
+# github.com/gardener/landscaper/controller-utils v0.48.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes
 github.com/gardener/landscaper/controller-utils/pkg/logging

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.18
 github.com/gardener/component-spec/bindings-go/apis/v2
 github.com/gardener/component-spec/bindings-go/utils/selector
-# github.com/gardener/landscaper/apis v0.47.0
+# github.com/gardener/landscaper/apis v0.48.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
@@ -46,7 +46,7 @@ github.com/gardener/landscaper/apis/core/v1alpha1/targettypes
 github.com/gardener/landscaper/apis/hack/generate-schemes/app
 github.com/gardener/landscaper/apis/hack/generate-schemes/generators
 github.com/gardener/landscaper/apis/schema
-# github.com/gardener/landscaper/controller-utils v0.47.0
+# github.com/gardener/landscaper/controller-utils v0.48.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/crdmanager
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request updates the landscaper version to `v0.48.0`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Landscaper version v0.48.0 contains the new templating function `getOidcKubeconfig` added in [Templating Function to Build OIDC Kubeconfigs #696](https://github.com/gardener/landscaper/pull/696) .

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- update landscaper version to v0.48.0
```
