### PR TITLE
Remove Secret with Static Sidecar Token

### DIFF
--- a/charts/sidecar-rbac/templates/serviceaccount.yaml
+++ b/charts/sidecar-rbac/templates/serviceaccount.yaml
@@ -14,16 +14,3 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
----
-apiVersion: v1
-kind: Secret
-type: kubernetes.io/service-account-token
-metadata:
-  name: {{ include "sidecar.serviceAccountName" . }}-token
-  labels:
-    {{- include "sidecar.labels" . | nindent 4 }}
-  annotations:
-    kubernetes.io/service-account.name: {{ include "sidecar.serviceAccountName" . }}
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request removes the Secret `sidecar-token` from the `sidecar` Helm chart.

Since pull request #111, the sidecar controllers of a landscaper instance do no longer use a static kubeconfig to access the resource cluster. However, the `sidecar` Helm chart still deploys the Secret, into which the static token is generated. As the static token is no longer used, we remove the Secret.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- rotation of the credentials that are used by the sidecar controllers to access the resource cluster
```
