### PR TITLE
ensure to delete target cluster namespace

### DIFF
--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -41,9 +41,7 @@ var (
 		new(tests.HelmDeployerTestRunner),
 		new(tests.ContainerDeployerTestRunner),
 		new(tests.DeleteDeploymentRunner),
-		// TODO: Test is currently not working since the landscaper
-		// deployer pods will not be destroyed automatically.
-		// new(tests.VerifyDeleteRunner),
+		new(tests.VerifyDeleteRunner),
 		new(tests.UninstallLAASTestRunner),
 	}
 )

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -256,10 +256,6 @@ func buildLandscaperValues(namespace string) ([]byte, error) {
 	const valuesTemplate = `
 landscaper:
   landscaper:
-    deployItemTimeouts:
-      pickup: 60m
-      abort: 60m
-      progressingDefault: 600m
     verbosity: debug
     registryConfig: # contains optional oci secrets
       allowPlainHttpRegistries: true

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"text/template"
+	"time"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -360,6 +361,9 @@ func cleanupResources(ctx context.Context, hostingClient, laasClient client.Clie
 		return err
 	}
 
+	// this should help prevent race conditions
+	time.Sleep(time.Second * 10)
+
 	if err := cliutil.DeleteNamespace(hostingClient, config.LaasNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err
 	}
@@ -376,6 +380,9 @@ func cleanupResources(ctx context.Context, hostingClient, laasClient client.Clie
 	if err := util.RemoveFinalizerLandscaperResources(ctx, hostingClient, config.TestNamespace); err != nil {
 		return err
 	}
+
+	// this should help prevent race conditions
+	time.Sleep(time.Second * 10)
 
 	if err := cliutil.DeleteNamespace(hostingClient, config.TestNamespace, config.SleepTime, config.MaxRetries); err != nil {
 		return err

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -256,10 +256,10 @@ func buildLandscaperValues(namespace string) ([]byte, error) {
 	const valuesTemplate = `
 landscaper:
   landscaper:
-	deployItemTimeouts:
-		pickup: 60m
-		abort: 60m
-		progressingDefault: 600m
+    deployItemTimeouts:
+      pickup: 60m
+      abort: 60m
+      progressingDefault: 600m
     verbosity: debug
     registryConfig: # contains optional oci secrets
       allowPlainHttpRegistries: true

--- a/integration-test/pkg/main.go
+++ b/integration-test/pkg/main.go
@@ -256,6 +256,10 @@ func buildLandscaperValues(namespace string) ([]byte, error) {
 	const valuesTemplate = `
 landscaper:
   landscaper:
+	deployItemTimeouts:
+		pickup: 60m
+		abort: 60m
+		progressingDefault: 600m
     verbosity: debug
     registryConfig: # contains optional oci secrets
       allowPlainHttpRegistries: true

--- a/integration-test/pkg/tests/test_delete_deployment.go
+++ b/integration-test/pkg/tests/test_delete_deployment.go
@@ -62,10 +62,12 @@ func (r *DeleteDeploymentRunner) deleteDeployment(deployment *lssv1alpha1.Landsc
 	}
 
 	logger.Info("waiting for deployment to be deleted", "name", deployment.Name)
+	maxRetries := int(LandscaperDeploymentInstallationTimeout.Seconds() / r.config.SleepTime.Seconds())
+
 	timeout, err := cliutil.CheckAndWaitUntilObjectNotExistAnymore(
 		r.clusterClients.TestCluster,
 		types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, deployment,
-		r.config.SleepTime, r.config.MaxRetries*10)
+		r.config.SleepTime, maxRetries)
 
 	if err != nil {
 		return fmt.Errorf("failed to wait for deployment %q to be deleted: %w", deployment.Name, err)

--- a/pkg/controllers/instances/add.go
+++ b/pkg/controllers/instances/add.go
@@ -30,6 +30,7 @@ func AddControllerToManager(logger logging.Logger, mgr manager.Manager, config *
 		For(&lssv1alpha1.Instance{}).
 		Owns(&lsv1alpha1.Installation{}).
 		Owns(&lsv1alpha1.Target{}).
+		Owns(&lsv1alpha1.Context{}).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
 		Complete(ctrl)
 }

--- a/pkg/controllers/instances/controller.go
+++ b/pkg/controllers/instances/controller.go
@@ -41,7 +41,7 @@ type Controller struct {
 	UniqueIDFunc func() string
 
 	ReconcileFunc    func(ctx context.Context, instance *lssv1alpha1.Instance) error
-	HandleDeleteFunc func(ctx context.Context, instance *lssv1alpha1.Instance) error
+	HandleDeleteFunc func(ctx context.Context, instance *lssv1alpha1.Instance) (reconcile.Result, error)
 	ListShootsFunc   func(ctx context.Context, instance *lssv1alpha1.Instance) (*unstructured.UnstructuredList, error)
 
 	kubeClientExtractor healthwatcher.ServiceTargetConfigKubeClientExtractorInterface
@@ -134,7 +134,8 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 
 	// reconcile delete
 	if !instance.DeletionTimestamp.IsZero() {
-		return reconcile.Result{}, errHdl(ctx, c.HandleDeleteFunc(ctx, instance))
+		result, err := c.HandleDeleteFunc(ctx, instance)
+		return result, errHdl(ctx, err)
 	}
 
 	if utils.HasOperationAnnotation(instance, lssv1alpha1.LandscaperServiceOperationIgnore) {

--- a/pkg/controllers/instances/controller.go
+++ b/pkg/controllers/instances/controller.go
@@ -9,14 +9,12 @@ import (
 	"fmt"
 	"reflect"
 
-	"k8s.io/utils/clock"
-
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
 	guuid "github.com/google/uuid"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -28,6 +26,7 @@ import (
 	coreconfig "github.com/gardener/landscaper-service/pkg/apis/config"
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
+	"github.com/gardener/landscaper-service/pkg/controllers/healthwatcher"
 	"github.com/gardener/landscaper-service/pkg/operation"
 	"github.com/gardener/landscaper-service/pkg/utils"
 )
@@ -44,6 +43,8 @@ type Controller struct {
 	ReconcileFunc    func(ctx context.Context, instance *lssv1alpha1.Instance) error
 	HandleDeleteFunc func(ctx context.Context, instance *lssv1alpha1.Instance) error
 	ListShootsFunc   func(ctx context.Context, instance *lssv1alpha1.Instance) (*unstructured.UnstructuredList, error)
+
+	kubeClientExtractor healthwatcher.ServiceTargetConfigKubeClientExtractorInterface
 }
 
 // NewUniqueID creates a new unique id string with a length of 8.
@@ -62,9 +63,10 @@ func defaultUniqueIdFunc() string {
 // NewController returns a new instances controller
 func NewController(logger logging.Logger, c client.Client, scheme *runtime.Scheme, config *coreconfig.LandscaperServiceConfiguration) (reconcile.Reconciler, error) {
 	ctrl := &Controller{
-		log:             logger,
-		UniqueIDFunc:    defaultUniqueIdFunc,
-		reconcileHelper: newAutomaticReconcileHelper(c, clock.RealClock{}),
+		log:                 logger,
+		UniqueIDFunc:        defaultUniqueIdFunc,
+		reconcileHelper:     newAutomaticReconcileHelper(c, clock.RealClock{}),
+		kubeClientExtractor: &healthwatcher.ServiceTargetConfigKubeClientExtractor{},
 	}
 	ctrl.ReconcileFunc = ctrl.reconcile
 	ctrl.HandleDeleteFunc = ctrl.handleDelete
@@ -72,6 +74,13 @@ func NewController(logger logging.Logger, c client.Client, scheme *runtime.Schem
 	op := operation.NewOperation(c, scheme, config)
 	ctrl.Operation = *op
 	return ctrl, nil
+}
+
+type TestKubeClientExtractor struct {
+}
+
+func (t *TestKubeClientExtractor) GetKubeClientFromServiceTargetConfig(_ context.Context, _ string, _ string, client client.Client) (client.Client, error) {
+	return client, nil
 }
 
 // NewTestActuator creates a new controller for testing purposes.
@@ -82,6 +91,7 @@ func NewTestActuator(op operation.Operation, logger logging.Logger) *Controller 
 		UniqueIDFunc:                 defaultUniqueIdFunc,
 		gardenerServiceAccountClient: op.Client(),
 		reconcileHelper:              newAutomaticReconcileHelper(op.Client(), clock.RealClock{}),
+		kubeClientExtractor:          &TestKubeClientExtractor{},
 	}
 	ctrl.ReconcileFunc = ctrl.reconcile
 	ctrl.HandleDeleteFunc = ctrl.handleDelete

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -129,6 +129,10 @@ func (c *Controller) mutateContext(ctx context.Context, context *lsv1alpha1.Cont
 		logger.Info("Creating context", lc.KeyResource, types.NamespacedName{Name: context.GenerateName, Namespace: context.Namespace}.String())
 	}
 
+	if err := controllerutil.SetControllerReference(instance, context, c.Scheme()); err != nil {
+		return fmt.Errorf("unable to set controller reference for target: %w", err)
+	}
+
 	repositoryContext := &cdv2.UnstructuredTypedObject{}
 	err := json.Unmarshal(c.Config().LandscaperServiceComponent.RepositoryContext.RawMessage, repositoryContext)
 

--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -7,8 +7,9 @@ package instances
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"

--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -214,7 +214,12 @@ func (c *Controller) deleteSecretsForContext(ctx context.Context, landscaperCont
 
 // ensureDeleteTargetClusterNamespace ensures that the target cluster namespace for an instance has been deleted.
 func (c *Controller) ensureDeleteTargetClusterNamespace(ctx context.Context, instance *lssv1alpha1.Instance) (bool, error) {
+	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(instance).String()},
+		lc.KeyMethod, "ensureDeleteTargetClusterNamespace")
+
 	targetClusterNamespace := fmt.Sprintf("%s-%s", instance.Spec.TenantId, instance.Spec.ID)
+
+	logger.Info("Delete target cluster namespace for instance", lc.KeyResourceNonNamespaced, targetClusterNamespace)
 
 	targetClusterClient, err := c.kubeClientExtractor.GetKubeClientFromServiceTargetConfig(
 		ctx,

--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	targetClusterNamespaceDeletionRetryDuration = time.Millisecond * 500
+	targetClusterNamespaceDeletionRetryDuration = time.Second * 10
 )
 
 // handleDelete handles the deletion of instances

--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -21,7 +21,6 @@ import (
 
 	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
-	"github.com/gardener/landscaper-service/pkg/controllers/healthwatcher"
 	"github.com/gardener/landscaper-service/pkg/utils"
 )
 
@@ -216,9 +215,8 @@ func (c *Controller) deleteSecretsForContext(ctx context.Context, landscaperCont
 // ensureDeleteTargetClusterNamespace ensures that the target cluster namespace for an instance has been deleted.
 func (c *Controller) ensureDeleteTargetClusterNamespace(ctx context.Context, instance *lssv1alpha1.Instance) (bool, error) {
 	targetClusterNamespace := fmt.Sprintf("%s-%s", instance.Spec.TenantId, instance.Spec.ID)
-	extr := healthwatcher.ServiceTargetConfigKubeClientExtractor{}
 
-	targetClusterClient, err := extr.GetKubeClientFromServiceTargetConfig(
+	targetClusterClient, err := c.kubeClientExtractor.GetKubeClientFromServiceTargetConfig(
 		ctx,
 		instance.Spec.ServiceTargetConfigRef.Name,
 		instance.Spec.ServiceTargetConfigRef.Namespace,

--- a/pkg/controllers/instances/reconcile_delete_test.go
+++ b/pkg/controllers/instances/reconcile_delete_test.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	lsserrors "github.com/gardener/landscaper-service/pkg/apis/errors"
 
 	. "github.com/onsi/ginkgo"
@@ -149,8 +151,8 @@ var _ = Describe("Delete", func() {
 
 		instance := state.GetInstance("test")
 
-		ctrl.HandleDeleteFunc = func(ctx context.Context, deployment *lssv1alpha1.Instance) error {
-			return lsserrors.NewWrappedError(fmt.Errorf(reason), operation, reason, message)
+		ctrl.HandleDeleteFunc = func(ctx context.Context, deployment *lssv1alpha1.Instance) (reconcile.Result, error) {
+			return reconcile.Result{}, lsserrors.NewWrappedError(fmt.Errorf(reason), operation, reason, message)
 		}
 
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))


### PR DESCRIPTION
**What this PR does / why we need it**:

When deleting a landscaper instance, the deployer pods remain in the target cluster namespace.
This PR ensures that the target cluster namespace is being deleted after the landscaper instance has been deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Ensure the target cluster namespace is being deleted when the corresponding landscaper instance has benn deleted.
```
