### PR TITLE
Improve AV check

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
@@ -11,6 +11,22 @@ deployItems:
       namespace: {{ .imports.hostingClusterNamespace }}
       createNamespace: true
 
+      readinessChecks:
+        disableDefault: false
+        custom:
+          - name: LsHealthCheckOk
+            timeout: 5m
+            resourceSelector:
+              - apiVersion: landscaper.gardener.cloud/v1alpha1
+                kind: LsHealthCheck
+                name: {{ .imports.hostingClusterNamespace }}
+                namespace: {{ .imports.hostingClusterNamespace }}
+            requirements:
+              - jsonPath: .status
+                operator: ==
+                values:
+                  - value: "Ok"
+
       chart:
         {{ $landscaperComponent := getComponent .cd "name" "landscaper" }}
         {{ $resource := getResource $landscaperComponent "name" "landscaper-controller-deployment-chart" }}

--- a/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
@@ -15,7 +15,7 @@ deployItems:
         disableDefault: false
         custom:
           - name: LsHealthCheckOk
-            timeout: 5m
+            timeout: 10m
             resourceSelector:
               - apiVersion: landscaper.gardener.cloud/v1alpha1
                 kind: LsHealthCheck

--- a/pkg/apis/config/types_landscaper_service_config.go
+++ b/pkg/apis/config/types_landscaper_service_config.go
@@ -56,7 +56,9 @@ type AvailabilityMonitoringConfiguration struct {
 
 	//PeriodicCheckInterval defines, how often the HealthWatcher controller collects the landscaper health information
 	PeriodicCheckInterval v1alpha1.Duration `json:"periodicCheckInterval"`
-	//LSHealthCheckTimeout defines the timeout, at which a previously available landscaper is unavailable if no updates occured
+	//LSHealthCheckTimeout defines the timeout, at which
+	// (1) a previously available landscaper is unavailable if no updates occured
+	// (2) a failed landscaper is reported as failed if it does not become available again
 	LSHealthCheckTimeout v1alpha1.Duration `json:"lsHealthCheckTimeout"`
 }
 

--- a/pkg/apis/config/v1alpha1/types_landscaper_service_config.go
+++ b/pkg/apis/config/v1alpha1/types_landscaper_service_config.go
@@ -56,7 +56,9 @@ type AvailabilityMonitoringConfiguration struct {
 
 	//PeriodicCheckInterval defines, how often the HealthWatcher controller collects the landscaper health information
 	PeriodicCheckInterval v1alpha1.Duration `json:"periodicCheckInterval"`
-	//LSHealthCheckTimeout defines the timeout, at which a previously available landscaper is unavailable if no updates occured
+	//LSHealthCheckTimeout defines the timeout, at which
+	// (1) a previously available landscaper is unavailable if no updates occured
+	// (2) a failed landscaper is reported as failed if it does not become available again
 	LSHealthCheckTimeout v1alpha1.Duration `json:"lsHealthCheckTimeout"`
 }
 

--- a/pkg/controllers/healthwatcher/controllger.go
+++ b/pkg/controllers/healthwatcher/controllger.go
@@ -250,10 +250,19 @@ func transferLsHealthCheckStatusToAvailabilityInstance(availabilityInstance *lss
 
 	healthCheck := lsHealthChecks.Items[0]
 	if time.Since(healthCheck.LastUpdateTime.Time) > timeout {
-		setAvailabilityInstanceStatusToFailed(availabilityInstance, fmt.Sprintf("timeout - last update time not recent enough (timeout %s)", timeout.String()))
+		if healthCheck.Status == lsv1alpha1.LsHealthCheckStatusOk {
+			setAvailabilityInstanceStatusToFailed(availabilityInstance, fmt.Sprintf("timeout - last update time not recent enough (timeout %s)", timeout.String()))
+		} else {
+			setAvailabilityInstanceStatusToFailed(availabilityInstance, healthCheck.Description)
+		}
 	} else {
-		availabilityInstance.Status = string(healthCheck.Status)
-		availabilityInstance.FailedReason = healthCheck.Description
+		if healthCheck.Status == lsv1alpha1.LsHealthCheckStatusOk {
+			availabilityInstance.Status = string(healthCheck.Status)
+		} else {
+			// if we are status failed but not yet in timeout, remain in Ok but put a remark in failedReason
+			availabilityInstance.Status = string(lsv1alpha1.LsHealthCheckStatusOk)
+			availabilityInstance.FailedReason = fmt.Sprintf("failed - waiting for timeout (%s) to transition to status=Failed", timeout.String())
+		}
 	}
 }
 

--- a/pkg/controllers/healthwatcher/controllger.go
+++ b/pkg/controllers/healthwatcher/controllger.go
@@ -253,7 +253,7 @@ func transferLsHealthCheckStatusToAvailabilityInstance(availabilityInstance *lss
 		if healthCheck.Status == lsv1alpha1.LsHealthCheckStatusOk {
 			setAvailabilityInstanceStatusToFailed(availabilityInstance, fmt.Sprintf("timeout - last update time not recent enough (timeout %s)", timeout.String()))
 		} else {
-			setAvailabilityInstanceStatusToFailed(availabilityInstance, healthCheck.Description)
+			setAvailabilityInstanceStatusToFailed(availabilityInstance, fmt.Sprintf("timeout - failed recovering from failed state within time (timeout %s): %s", timeout.String(), healthCheck.Description))
 		}
 	} else {
 		if healthCheck.Status == lsv1alpha1.LsHealthCheckStatusOk {


### PR DESCRIPTION
**What this PR does / why we need it**:
Improves AV check:
- LaaS landscaper installation will only succeed if the lsHealthCheck object exists and is in Ok
- The timeout option now also applies to a failed lsHealthCheck: if an lsHealthCheck changes to failed, the instance availability will be set to failed if the lsHealthCheck status does not transition to Ok within the configured timeout.

**Which issue(s) this PR fixes**:
Fixes availability downtime report when creating (or updating) a landscaper instance, since the absence of the lsHealthCheck CR while the controllers are starting is seen as unavailable. The monitoring of the a landscaper instance now begins, when the lsHealthCheck object is in Ok.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- LaaS landscaper installation now has a custom readiness check for lsHealthCheck
- Failed lsHealthCheck only result in an unavailable instance if it does not changes to Ok within the timeout
```
