### PR TITLE
FixAVCheck during instance deletion

### DIFF
--- a/pkg/controllers/avmonitorregistration/controller.go
+++ b/pkg/controllers/avmonitorregistration/controller.go
@@ -62,6 +62,12 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		logger, ctx := logging.FromContextOrNew(ctx, nil, "instance", types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}.String())
 		logger.Debug("register instance")
 
+		//skip instances in deletion
+		if !instance.DeletionTimestamp.IsZero() {
+			logger.Debug("skip instance since it is in deletion")
+			continue
+		}
+
 		//get refered installation
 		logger.Debug("fetch referred installation")
 		if instance.Status.InstallationRef == nil || instance.Status.InstallationRef.Name == "" || instance.Status.InstallationRef.Namespace == "" {

--- a/pkg/controllers/avmonitorregistration/reconcile_test.go
+++ b/pkg/controllers/avmonitorregistration/reconcile_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, types.NamespacedName{Namespace: op.Config().AvailabilityMonitoring.AvailabilityCollectionNamespace, Name: op.Config().AvailabilityMonitoring.AvailabilityCollectionName}, availabilitycollection)).To(Succeed())
 		Expect(len(availabilitycollection.Spec.InstanceRefs)).To(Equal(1))
 
-		//delete instance
+		//delete instance (with a finalizer, simulating a long deletion procedure)
 		Expect(testenv.Client.Delete(ctx, instance)).To(Succeed())
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
 

--- a/pkg/controllers/avmonitorregistration/testdata/reconcile/test2/instance.yaml
+++ b/pkg/controllers/avmonitorregistration/testdata/reconcile/test2/instance.yaml
@@ -7,6 +7,8 @@ kind: Instance
 metadata:
   name: "test"
   namespace: {{ .Namespace }}
+  finalizers:
+  - unittest
 spec:
   tenantId: "12345"
   id: "abcdef"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- AV checking for an instance now stops as soon as a deletion timestamp is set
```
