### PR TITLE
ensure that resource names and namespaces are of type string

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -17,8 +17,8 @@ deployItems:
             resourceSelector:
               - apiVersion: core.gardener.cloud/v1beta1
                 kind: Shoot
-                name: {{ .imports.name }}
-                namespace: {{ .imports.namespace }}
+                name: "{{ .imports.name }}"
+                namespace: "{{ .imports.namespace }}"
             requirements:
               - jsonPath: .status.conditions[?(@.type == 'APIServerAvailable')].status
                 operator: ==
@@ -46,8 +46,8 @@ deployItems:
             apiVersion: v1
             kind: ConfigMap
             metadata:
-              name: {{ .imports.name }}-audit-policy
-              namespace: {{ .imports.namespace }}
+              name: "{{ .imports.name }}-audit-policy"
+              namespace: "{{ .imports.namespace }}"
             {{ if .imports.labels }}
               labels:
 {{ toYaml .imports.labels | indent 16 }}
@@ -64,13 +64,13 @@ deployItems:
             apiVersion: core.gardener.cloud/v1beta1
             kind: Shoot
             metadata:
-              name: {{ .imports.name }}
-              namespace: {{ .imports.namespace }}
+              name: "{{ .imports.name }}"
+              namespace: "{{ .imports.namespace }}"
               annotations:
                 shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds: '30'
                 gardener.cloud/operation: reconcile
                 {{ if .imports.subaccountId }}
-                custom.shoot.sapcloud.io/subaccountId: {{ .imports.subaccountId }}
+                custom.shoot.sapcloud.io/subaccountId: "{{ .imports.subaccountId }}"
                 {{ end }}
             {{ if .imports.labels }}
               labels:
@@ -145,5 +145,5 @@ deployItems:
             fromResource:
               apiVersion: core.gardener.cloud/v1beta1
               kind: Shoot
-              name: {{ .imports.name }}
-              namespace: {{ .imports.namespace }}
+              name: "{{ .imports.name }}"
+              namespace: "{{ .imports.namespace }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating a shoot with a name that only contains numerical values, the name is interpreted as an integer while parsing the yaml manifest.
Wrap the name and namespace values of these manifests with double qoutes to enforce the string type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Wrap the name and namespace values of Shooz manifests with double qoutes to enforce the string type.
```
