### PR TITLE
Higher availability of ingress controller

### DIFF
--- a/.landscaper/ingress-controller/blueprint/deploy-execution.yaml
+++ b/.landscaper/ingress-controller/blueprint/deploy-execution.yaml
@@ -37,3 +37,23 @@ deployItems:
           extraArgs:
             enable-ssl-passthrough: true
             annotations-prefix: nginx.ingress.kubernetes.io
+
+          replicaCount: 2
+
+          topologySpreadConstraints:
+          - maxSkew: 1
+            topologyKey: topology.kubernetes.io/zone
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+              app.kubernetes.io/instance: ingress-nginx
+              app.kubernetes.io/component: controller
+          - maxSkew: 1
+            topologyKey: kubernetes.io/hostname
+            whenUnsatisfiable: ScheduleAnyway
+            labelSelector:
+              matchLabels:
+                app.kubernetes.io/name: ingress-nginx
+                app.kubernetes.io/instance: ingress-nginx
+                app.kubernetes.io/component: controller


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR increases the replicas of the ingress component to 2 and adds a configuration such that the pods are distributed over different zones and nodes. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- increase replicas of ingress controller and improve uniform distribution
```
