### PR TITLE
No minor shoot version and upgrade to Landscaper v0.54.0

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -22,7 +22,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.25.5"
+    "version": "1.25"
   },
   "maintenance": {
     "timeWindow": {

--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -115,7 +115,7 @@ deployItems:
               region: {{ .imports.shootConfig.region }}
               secretBindingName: {{ .imports.secretBindingName }}
               kubernetes:
-                version: {{ .imports.shootConfig.kubernetes.version }}
+                version: "{{ .imports.shootConfig.kubernetes.version }}"
                 enableStaticTokenKubeconfig: false
                 kubeAPIServer:
                   {{ if ((.imports.shootConfig.kubernetes.kubeAPIServer).oidcConfig) }}

--- a/.landscaper/landscaper-instance/component-references.yaml
+++ b/.landscaper/landscaper-instance/component-references.yaml
@@ -1,5 +1,5 @@
 ---
 componentName: github.com/gardener/landscaper
 name: landscaper
-version: v0.53.0
+version: v0.54.0
 ...

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.19
 
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.66
-	github.com/gardener/landscaper/apis v0.53.0
-	github.com/gardener/landscaper/controller-utils v0.53.0
+	github.com/gardener/landscaper/apis v0.54.0
+	github.com/gardener/landscaper/controller-utils v0.54.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.1.2
 	github.com/onsi/ginkgo v1.16.5

--- a/go.sum
+++ b/go.sum
@@ -99,10 +99,10 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/gardener/component-spec/bindings-go v0.0.66 h1:FvtnnTxXJi2ZCC/GgijUNJCcwwdlZAiEWpZTtyHviz0=
 github.com/gardener/component-spec/bindings-go v0.0.66/go.mod h1:qr7kADDXbXB0huul+ih/B43YkwyiMFYQepp/tqJ331c=
-github.com/gardener/landscaper/apis v0.53.0 h1:PMOTv8obGzjfiLyY9Wj3fC86iTSYLCkPQ2OyYNuJs6M=
-github.com/gardener/landscaper/apis v0.53.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
-github.com/gardener/landscaper/controller-utils v0.53.0 h1:wtHQeW1stnLoecrdXiSdToeCTngil8EOlAlZJn6FkTA=
-github.com/gardener/landscaper/controller-utils v0.53.0/go.mod h1:OCPX4Od5gzQpofK1NXFB4FwCdHFYFi5EOuaTVW4N1ik=
+github.com/gardener/landscaper/apis v0.54.0 h1:XK5iqy48DTpCxptHBFVpg2fYnL7uXBTuNYDcsEEwPU8=
+github.com/gardener/landscaper/apis v0.54.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
+github.com/gardener/landscaper/controller-utils v0.54.0 h1:GPCPq0YlKZ7OW2X4PBO7OfmLxmdXenEOLVtA8VFe05g=
+github.com/gardener/landscaper/controller-utils v0.54.0/go.mod h1:RLmO1ZW6uoFjoAZaSueSViFwxX1bandfumc2ymfxLIg=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=

--- a/integration-test/go.mod
+++ b/integration-test/go.mod
@@ -5,8 +5,8 @@ go 1.19
 require (
 	github.com/gardener/component-spec/bindings-go v0.0.66
 	github.com/gardener/landscaper-service v0.0.0-00010101000000-000000000000
-	github.com/gardener/landscaper/apis v0.53.0
-	github.com/gardener/landscaper/controller-utils v0.53.0
+	github.com/gardener/landscaper/apis v0.54.0
+	github.com/gardener/landscaper/controller-utils v0.54.0
 	github.com/gardener/landscapercli v0.21.0
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.26.1

--- a/integration-test/go.sum
+++ b/integration-test/go.sum
@@ -103,10 +103,10 @@ github.com/gardener/component-spec/bindings-go v0.0.66/go.mod h1:qr7kADDXbXB0huu
 github.com/gardener/image-vector v0.10.0 h1:Ysg3hxfiGUG/doajiZ0nQuUaJYwfO5BZCOcijL3tRuo=
 github.com/gardener/landscaper v0.52.0 h1:jIaVtyGjS1OIoDdOXOYnF91hZA0q2YFC4h8LBfOSYbw=
 github.com/gardener/landscaper v0.52.0/go.mod h1:zQdeb1pC75ou9MVSos19MG1MSel5t9u11UWQO1SXK68=
-github.com/gardener/landscaper/apis v0.53.0 h1:PMOTv8obGzjfiLyY9Wj3fC86iTSYLCkPQ2OyYNuJs6M=
-github.com/gardener/landscaper/apis v0.53.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
-github.com/gardener/landscaper/controller-utils v0.53.0 h1:wtHQeW1stnLoecrdXiSdToeCTngil8EOlAlZJn6FkTA=
-github.com/gardener/landscaper/controller-utils v0.53.0/go.mod h1:OCPX4Od5gzQpofK1NXFB4FwCdHFYFi5EOuaTVW4N1ik=
+github.com/gardener/landscaper/apis v0.54.0 h1:XK5iqy48DTpCxptHBFVpg2fYnL7uXBTuNYDcsEEwPU8=
+github.com/gardener/landscaper/apis v0.54.0/go.mod h1:hrnDwYI9jqI6azU3MhQ8gUjITgf2L+qfVuv/s5nlMgo=
+github.com/gardener/landscaper/controller-utils v0.54.0 h1:GPCPq0YlKZ7OW2X4PBO7OfmLxmdXenEOLVtA8VFe05g=
+github.com/gardener/landscaper/controller-utils v0.54.0/go.mod h1:RLmO1ZW6uoFjoAZaSueSViFwxX1bandfumc2ymfxLIg=
 github.com/gardener/landscapercli v0.21.0 h1:FbIVNMUUQod74uVbh79TiHLDNxbuE1LET8ukfvL8w1Y=
 github.com/gardener/landscapercli v0.21.0/go.mod h1:tZzrKBf8wfMHDZVk6qwO7tymrbC7OWIOAnanotv+ANU=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=

--- a/integration-test/vendor/modules.txt
+++ b/integration-test/vendor/modules.txt
@@ -94,7 +94,7 @@ github.com/gardener/landscaper-service/pkg/apis/core
 github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1
 github.com/gardener/landscaper-service/pkg/apis/installation
 github.com/gardener/landscaper-service/pkg/utils
-# github.com/gardener/landscaper/apis v0.53.0
+# github.com/gardener/landscaper/apis v0.54.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/config/install
@@ -115,7 +115,7 @@ github.com/gardener/landscaper/apis/deployer/utils/readinesschecks
 github.com/gardener/landscaper/apis/errors
 github.com/gardener/landscaper/apis/mediatype
 github.com/gardener/landscaper/apis/schema
-# github.com/gardener/landscaper/controller-utils v0.53.0
+# github.com/gardener/landscaper/controller-utils v0.54.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes
 github.com/gardener/landscaper/controller-utils/pkg/logging

--- a/pkg/controllers/instances/controller.go
+++ b/pkg/controllers/instances/controller.go
@@ -7,6 +7,7 @@ package instances
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 
 	guuid "github.com/google/uuid"
@@ -30,6 +31,8 @@ import (
 	"github.com/gardener/landscaper-service/pkg/operation"
 	"github.com/gardener/landscaper-service/pkg/utils"
 )
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 
 // Controller is the instances controller
 type Controller struct {
@@ -57,7 +60,14 @@ func (c *Controller) NewUniqueID() string {
 }
 
 func defaultUniqueIdFunc() string {
-	return guuid.New().String()
+	// it must be prevented that the first 8 chars are numbers
+	// this part is used for generating the shoot name but also machine names of a shoot and this is not allowed
+
+	id := guuid.New().String()
+	id = id[1:]
+	s := string(letterRunes[rand.Intn(len(letterRunes))])
+	t := s + id
+	return t
 }
 
 // NewController returns a new instances controller

--- a/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
+++ b/vendor/github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates.go
@@ -12,12 +12,13 @@ import (
 	"os"
 	"path/filepath"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/webhook/certificates"
 )
@@ -53,12 +54,8 @@ func GetDNSNamesFromURL(rawurl string) ([]string, error) {
 
 // GenerateCertificates generates the certificates that are required for a webhook. It returns the ca bundle, and it
 // stores the server certificate and key locally on the file system.
-func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string, dnsNames []string) ([]byte, error) {
-	var (
-		caCert     *certificates.Certificate
-		serverCert *certificates.Certificate
-		err        error
-	)
+func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir, namespace, name, certSecretName string,
+	dnsNames []string) ([]byte, error) {
 
 	caConfig := &certificates.CertificateSecretConfig{
 		CommonName: "webhook-ca",
@@ -66,72 +63,98 @@ func GenerateCertificates(ctx context.Context, kubeClient client.Client, certDir
 		PKCS:       certificates.PKCS8,
 	}
 
-	// If the namespace is not set then the webhook controller is running locally. We simply generate a new certificate in this case.
-	if len(namespace) == 0 {
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
-		if err != nil {
-			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
-		}
-		return writeCertificates(certDir, caCert, serverCert)
-	}
-
 	// The controller stores the generated webhook certificate in a secret in the cluster. It tries to read it. If it does not exist a
 	// new certificate is generated.
 
-	generateAndUpdateCertificate := func() ([]byte, error) {
-		// The secret was not found, let's generate new certificates and store them in the secret afterwards.
-		caCert, serverCert, err = GenerateNewCAAndServerCert(name, dnsNames, *caConfig)
+	secret := &corev1.Secret{}
+	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+
+		if !apierrors.IsNotFound(err) {
+			return nil, errors.Wrapf(err, "error fetching secret for webhook server")
+		}
+
+		caCert, serverCert, err := generateNewCAAndServerCert(name, dnsNames, *caConfig)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error generating new certificates for webhook server")
 		}
 
-		secret := &corev1.Secret{}
-		secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
-		secret.Type = corev1.SecretTypeOpaque
-		secret.Data = map[string][]byte{
-			certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-			certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-			certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-			certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
-		}
-
-		if _, err := controllerutil.CreateOrUpdate(ctx, kubeClient, secret, func() error {
-			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = map[string][]byte{
-				certificates.DataKeyCertificateCA: caCert.CertificatePEM,
-				certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
-				certificates.DataKeyCertificate:   serverCert.CertificatePEM,
-				certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+		err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, namespace, certSecretName, true)
+		if err == nil {
+			return writeCertificates(certDir, caCert, serverCert)
+		} else {
+			// try to refetch secret if it was created by another replica
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				return nil, errors.Wrapf(err, "could not fetch secret for webhook")
 			}
-			return nil
-		}); err != nil {
+		}
+	}
+
+	// The secret has been found and we are now trying to read the stored certificate inside it and updates it if
+	// required
+	caCert, serverCert, retry, err := loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+	if err != nil {
+		if retry {
+			secret = &corev1.Secret{}
+			if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
+				caCert, serverCert, _, err = loadAndUpdateSecret(ctx, kubeClient, secret, name, dnsNames, caConfig)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
 			return nil, err
 		}
 
-		return writeCertificates(certDir, caCert, serverCert)
-	}
-
-	secret := &corev1.Secret{}
-	if err := kubeClient.Get(ctx, client.ObjectKey{Namespace: namespace, Name: certSecretName}, secret); err != nil {
-		return generateAndUpdateCertificate()
-	}
-
-	// The secret has been found and we are now trying to read the stored certificate inside it.
-	caCert, serverCert, err = loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error reading data of secret %s/%s", namespace, certSecretName)
-	}
-
-	// update certificates if the dns names have changed
-	if !sets.NewString(caCert.Certificate.DNSNames...).HasAll(dnsNames...) {
-		return generateAndUpdateCertificate()
 	}
 
 	return writeCertificates(certDir, caCert, serverCert)
 }
 
+func loadAndUpdateSecret(ctx context.Context, kubeClient client.Client, secret *corev1.Secret, name string, dnsNames []string,
+	caConfig *certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, bool, error) {
+
+	caCert, serverCert, err := loadExistingCAAndServerCert(secret.Data, caConfig.PKCS)
+	if err != nil {
+		return nil, nil, false, errors.Wrapf(err, "error reading data of secret %s/%s", secret.Namespace, secret.Name)
+	}
+
+	// update certificates if the dns names have changed
+	if !sets.NewString(serverCert.Certificate.DNSNames...).HasAll(dnsNames...) {
+		caCert, serverCert, err = generateNewCAAndServerCert(name, dnsNames, *caConfig)
+		if err != nil {
+			return nil, nil, false, errors.Wrapf(err, "error generating new certificates for webhook server")
+		}
+
+		if err = createOrUpdateSecret(ctx, kubeClient, caCert, serverCert, secret.Namespace, secret.Name, false); err != nil {
+			return nil, nil, true, errors.Wrapf(err, "error updating secret for webhook")
+		}
+	}
+
+	return caCert, serverCert, false, nil
+}
+
+func createOrUpdateSecret(ctx context.Context, kubeClient client.Client, caCert, serverCert *certificates.Certificate,
+	namespace, certSecretName string, create bool) error {
+	// The secret was not found, let's generate new certificates and store them in the secret afterwards.
+	secret := &corev1.Secret{}
+	secret.ObjectMeta = metav1.ObjectMeta{Namespace: namespace, Name: certSecretName}
+	secret.Type = corev1.SecretTypeOpaque
+	secret.Data = map[string][]byte{
+		certificates.DataKeyCertificateCA: caCert.CertificatePEM,
+		certificates.DataKeyPrivateKeyCA:  caCert.PrivateKeyPEM,
+		certificates.DataKeyCertificate:   serverCert.CertificatePEM,
+		certificates.DataKeyPrivateKey:    serverCert.PrivateKeyPEM,
+	}
+
+	if create {
+		return kubeClient.Create(ctx, secret)
+	} else {
+		return kubeClient.Update(ctx, secret)
+	}
+}
+
 // GenerateNewCAAndServerCert generates a new ca and server certificate for a service in a name and namespace.
-func GenerateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
+func generateNewCAAndServerCert(name string, dnsNames []string, caConfig certificates.CertificateSecretConfig) (*certificates.Certificate, *certificates.Certificate, error) {
 	caCert, err := caConfig.GenerateCertificate()
 	if err != nil {
 		return nil, nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -36,7 +36,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.18
 github.com/gardener/component-spec/bindings-go/apis/v2
 github.com/gardener/component-spec/bindings-go/utils/selector
-# github.com/gardener/landscaper/apis v0.53.0
+# github.com/gardener/landscaper/apis v0.54.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
@@ -46,7 +46,7 @@ github.com/gardener/landscaper/apis/core/v1alpha1/targettypes
 github.com/gardener/landscaper/apis/hack/generate-schemes/app
 github.com/gardener/landscaper/apis/hack/generate-schemes/generators
 github.com/gardener/landscaper/apis/schema
-# github.com/gardener/landscaper/controller-utils v0.53.0
+# github.com/gardener/landscaper/controller-utils v0.54.0
 ## explicit; go 1.19
 github.com/gardener/landscaper/controller-utils/pkg/crdmanager
 github.com/gardener/landscaper/controller-utils/pkg/kubernetes


### PR DESCRIPTION
**What this PR does / why we need it**:

No minor shoot version in LaaS component specified, such that the latest version is selected by Gardener automatically.
Upgrade to Landscaper v0.54.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- No minor shoot version, such that the latest version is fetched automatically
- Upgrade to Landscaper v0.54.0
```
