### PR TITLE
restart laas deployment on config change

### DIFF
--- a/charts/landscaper-service/templates/deployment-controller.yaml
+++ b/charts/landscaper-service/templates/deployment-controller.yaml
@@ -16,6 +16,8 @@ spec:
       {{- include "landscaper-service.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include "landscaper-service-config" . | sha256sum }}
       labels:
         {{- include "landscaper-service.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Added the config's hash as an annotation to the deployment's pod template. This should have the effect that the laas pods are restarted if the config changed during a `helm update`.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
LaaS pods will now restart if `helm update` is executed and the config has changed.
```
