### PR TITLE
create a dedicated gardener service account target for an instance

### DIFF
--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/type_instance.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/type_instance.go
@@ -88,6 +88,10 @@ type InstanceStatus struct {
 	// +optional
 	TargetRef *ObjectReference `json:"targetRef"`
 
+	// GardenerServiceAccountRef references the Target for the Gardener service account.
+	// +optional
+	GardenerServiceAccountRef *ObjectReference `json:"gardenerServiceAccountRef"`
+
 	// InstallationRef references the Installation for this Instance.
 	// +optional
 	InstallationRef *ObjectReference `json:"installationRef"`

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_instance.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_instance.go
@@ -89,6 +89,10 @@ type InstanceStatus struct {
 	// +optional
 	TargetRef *ObjectReference `json:"targetRef,omitempty"`
 
+	// GardenerServiceAccountRef references the Target for the Gardener service account.
+	// +optional
+	GardenerServiceAccountRef *ObjectReference `json:"gardenerServiceAccountRef"`
+
 	// InstallationRef references the Installation for this Instance.
 	// +optional
 	InstallationRef *ObjectReference `json:"installationRef,omitempty"`

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -669,6 +669,7 @@ func autoConvert_v1alpha1_InstanceStatus_To_core_InstanceStatus(in *InstanceStat
 	out.LandscaperServiceComponent = (*core.LandscaperServiceComponent)(unsafe.Pointer(in.LandscaperServiceComponent))
 	out.ContextRef = (*core.ObjectReference)(unsafe.Pointer(in.ContextRef))
 	out.TargetRef = (*core.ObjectReference)(unsafe.Pointer(in.TargetRef))
+	out.GardenerServiceAccountRef = (*core.ObjectReference)(unsafe.Pointer(in.GardenerServiceAccountRef))
 	out.InstallationRef = (*core.ObjectReference)(unsafe.Pointer(in.InstallationRef))
 	out.ClusterEndpoint = in.ClusterEndpoint
 	out.UserKubeconfig = in.UserKubeconfig
@@ -690,6 +691,7 @@ func autoConvert_core_InstanceStatus_To_v1alpha1_InstanceStatus(in *core.Instanc
 	out.LandscaperServiceComponent = (*LandscaperServiceComponent)(unsafe.Pointer(in.LandscaperServiceComponent))
 	out.ContextRef = (*ObjectReference)(unsafe.Pointer(in.ContextRef))
 	out.TargetRef = (*ObjectReference)(unsafe.Pointer(in.TargetRef))
+	out.GardenerServiceAccountRef = (*ObjectReference)(unsafe.Pointer(in.GardenerServiceAccountRef))
 	out.InstallationRef = (*ObjectReference)(unsafe.Pointer(in.InstallationRef))
 	out.ClusterEndpoint = in.ClusterEndpoint
 	out.UserKubeconfig = in.UserKubeconfig

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *InstanceStatus) DeepCopyInto(out *InstanceStatus) {
 		*out = new(ObjectReference)
 		**out = **in
 	}
+	if in.GardenerServiceAccountRef != nil {
+		in, out := &in.GardenerServiceAccountRef, &out.GardenerServiceAccountRef
+		*out = new(ObjectReference)
+		**out = **in
+	}
 	if in.InstallationRef != nil {
 		in, out := &in.InstallationRef, &out.InstallationRef
 		*out = new(ObjectReference)

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/zz_generated.deepcopy.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *InstanceStatus) DeepCopyInto(out *InstanceStatus) {
 		*out = new(ObjectReference)
 		**out = **in
 	}
+	if in.GardenerServiceAccountRef != nil {
+		in, out := &in.GardenerServiceAccountRef, &out.GardenerServiceAccountRef
+		*out = new(ObjectReference)
+		**out = **in
+	}
 	if in.InstallationRef != nil {
 		in, out := &in.InstallationRef, &out.InstallationRef
 		*out = new(ObjectReference)

--- a/pkg/apis/.schemes/core-v1alpha1-Instance.json
+++ b/pkg/apis/.schemes/core-v1alpha1-Instance.json
@@ -128,6 +128,10 @@
           "description": "ContextRef references the landscaper context for this Instance.",
           "$ref": "#/definitions/core-v1alpha1-ObjectReference"
         },
+        "gardenerServiceAccountRef": {
+          "description": "GardenerServiceAccountRef references the Target for the Gardener service account.",
+          "$ref": "#/definitions/core-v1alpha1-ObjectReference"
+        },
         "installationRef": {
           "description": "InstallationRef references the Installation for this Instance.",
           "$ref": "#/definitions/core-v1alpha1-ObjectReference"

--- a/pkg/apis/core/type_instance.go
+++ b/pkg/apis/core/type_instance.go
@@ -88,6 +88,10 @@ type InstanceStatus struct {
 	// +optional
 	TargetRef *ObjectReference `json:"targetRef"`
 
+	// GardenerServiceAccountRef references the Target for the Gardener service account.
+	// +optional
+	GardenerServiceAccountRef *ObjectReference `json:"gardenerServiceAccountRef"`
+
 	// InstallationRef references the Installation for this Instance.
 	// +optional
 	InstallationRef *ObjectReference `json:"installationRef"`

--- a/pkg/apis/core/v1alpha1/types_instance.go
+++ b/pkg/apis/core/v1alpha1/types_instance.go
@@ -89,6 +89,10 @@ type InstanceStatus struct {
 	// +optional
 	TargetRef *ObjectReference `json:"targetRef,omitempty"`
 
+	// GardenerServiceAccountRef references the Target for the Gardener service account.
+	// +optional
+	GardenerServiceAccountRef *ObjectReference `json:"gardenerServiceAccountRef"`
+
 	// InstallationRef references the Installation for this Instance.
 	// +optional
 	InstallationRef *ObjectReference `json:"installationRef,omitempty"`

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -669,6 +669,7 @@ func autoConvert_v1alpha1_InstanceStatus_To_core_InstanceStatus(in *InstanceStat
 	out.LandscaperServiceComponent = (*core.LandscaperServiceComponent)(unsafe.Pointer(in.LandscaperServiceComponent))
 	out.ContextRef = (*core.ObjectReference)(unsafe.Pointer(in.ContextRef))
 	out.TargetRef = (*core.ObjectReference)(unsafe.Pointer(in.TargetRef))
+	out.GardenerServiceAccountRef = (*core.ObjectReference)(unsafe.Pointer(in.GardenerServiceAccountRef))
 	out.InstallationRef = (*core.ObjectReference)(unsafe.Pointer(in.InstallationRef))
 	out.ClusterEndpoint = in.ClusterEndpoint
 	out.UserKubeconfig = in.UserKubeconfig
@@ -690,6 +691,7 @@ func autoConvert_core_InstanceStatus_To_v1alpha1_InstanceStatus(in *core.Instanc
 	out.LandscaperServiceComponent = (*LandscaperServiceComponent)(unsafe.Pointer(in.LandscaperServiceComponent))
 	out.ContextRef = (*ObjectReference)(unsafe.Pointer(in.ContextRef))
 	out.TargetRef = (*ObjectReference)(unsafe.Pointer(in.TargetRef))
+	out.GardenerServiceAccountRef = (*ObjectReference)(unsafe.Pointer(in.GardenerServiceAccountRef))
 	out.InstallationRef = (*ObjectReference)(unsafe.Pointer(in.InstallationRef))
 	out.ClusterEndpoint = in.ClusterEndpoint
 	out.UserKubeconfig = in.UserKubeconfig

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *InstanceStatus) DeepCopyInto(out *InstanceStatus) {
 		*out = new(ObjectReference)
 		**out = **in
 	}
+	if in.GardenerServiceAccountRef != nil {
+		in, out := &in.GardenerServiceAccountRef, &out.GardenerServiceAccountRef
+		*out = new(ObjectReference)
+		**out = **in
+	}
 	if in.InstallationRef != nil {
 		in, out := &in.InstallationRef, &out.InstallationRef
 		*out = new(ObjectReference)

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -301,6 +301,11 @@ func (in *InstanceStatus) DeepCopyInto(out *InstanceStatus) {
 		*out = new(ObjectReference)
 		**out = **in
 	}
+	if in.GardenerServiceAccountRef != nil {
+		in, out := &in.GardenerServiceAccountRef, &out.GardenerServiceAccountRef
+		*out = new(ObjectReference)
+		**out = **in
+	}
 	if in.InstallationRef != nil {
 		in, out := &in.InstallationRef, &out.InstallationRef
 		*out = new(ObjectReference)

--- a/pkg/apis/openapi/openapi_generated.go
+++ b/pkg/apis/openapi/openapi_generated.go
@@ -948,6 +948,12 @@ func schema_pkg_apis_core_v1alpha1_InstanceStatus(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1.ObjectReference"),
 						},
 					},
+					"gardenerServiceAccountRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerServiceAccountRef references the Target for the Gardener service account.",
+							Ref:         ref("github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1.ObjectReference"),
+						},
+					},
 					"installationRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "InstallationRef references the Installation for this Instance.",
@@ -3040,7 +3046,7 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 					},
 					"timeout": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Timeout specifies how long the deployer may take to apply the deploy item. When the time is exceeded, the landscaper will add the abort annotation to the deploy item and later put it in 'Failed' if the deployer doesn't handle the abort properly. Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout). Defaults to ten minutes if not specified.",
+							Description: "Timeout specifies how long the deployer may take to apply the deploy item. When the time is exceeded, the deploy item fails. Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout). Defaults to ten minutes if not specified.",
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.Duration"),
 						},
 					},
@@ -3168,7 +3174,7 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemStatus(ref common.ReferenceC
 					},
 					"deployItemPhase": {
 						SchemaProps: spec.SchemaProps{
-							Description: "DeployItemPhase is the current phase of the deploy item.",
+							Description: "DeployerPhase is DEPRECATED and will soon be removed.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -3248,6 +3254,12 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemTemplate(ref common.Referenc
 							},
 						},
 					},
+					"timeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Timeout specifies how long the deployer may take to apply the deploy item. When the time is exceeded, the deploy item fails. Value has to be parsable by time.ParseDuration (or 'none' to deactivate the timeout). Defaults to ten minutes if not specified.",
+							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.Duration"),
+						},
+					},
 					"updateOnChangeOnly": {
 						SchemaProps: spec.SchemaProps{
 							Description: "UpdateOnChangeOnly specifies if redeployment is executed only if the specification of the deploy item has changed.",
@@ -3260,7 +3272,7 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemTemplate(ref common.Referenc
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.Duration", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 
@@ -4003,11 +4015,17 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionStatus(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"phaseTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PhaseTransitionTime is the time when the phase last changed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ExecutionGeneration", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ExecutionGeneration", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.VersionedNamedObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -4682,6 +4700,12 @@ func schema_landscaper_apis_core_v1alpha1_InstallationStatus(ref common.Referenc
 							Format:      "",
 						},
 					},
+					"phaseTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PhaseTransitionTime is the time when the phase last changed.",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 					"importsHash": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ImportsHash is the hash of the import data.",
@@ -4700,7 +4724,7 @@ func schema_landscaper_apis_core_v1alpha1_InstallationStatus(ref common.Referenc
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcileStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ImportStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.NamedObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcileStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.Condition", "github.com/gardener/landscaper/apis/core/v1alpha1.Error", "github.com/gardener/landscaper/apis/core/v1alpha1.ImportStatus", "github.com/gardener/landscaper/apis/core/v1alpha1.NamedObjectReference", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference", "k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -481,11 +481,11 @@ func (c *Controller) mutateInstallation(ctx context.Context, installation *lsv1a
 			Targets: []lsv1alpha1.TargetImport{
 				{
 					Name:   "hostingCluster",
-					Target: fmt.Sprintf("#%s", instance.Status.TargetRef.Name),
+					Target: instance.Status.TargetRef.Name,
 				},
 				{
 					Name:   "gardenerServiceAccount",
-					Target: fmt.Sprintf("#%s", instance.Status.GardenerServiceAccountRef.Name),
+					Target: instance.Status.GardenerServiceAccountRef.Name,
 				},
 			},
 		},

--- a/pkg/controllers/instances/reconcile_delete_test.go
+++ b/pkg/controllers/instances/reconcile_delete_test.go
@@ -108,6 +108,7 @@ var _ = Describe("Delete", func() {
 
 		instance := state.GetInstance("test")
 		target := state.GetTarget("test")
+		gardenerSa := state.GetTarget("test-gardener-sa")
 		installation := state.GetInstallation("test")
 		context := state.GetContext("test")
 
@@ -121,11 +122,14 @@ var _ = Describe("Delete", func() {
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
 		// target
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
+		// gardener service account
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
 		// context
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(instance))
 
 		Expect(testenv.WaitForObjectToBeDeleted(ctx, instance, 5*time.Second)).To(Succeed())
 		Expect(testenv.WaitForObjectToBeDeleted(ctx, target, 5*time.Second)).To(Succeed())
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, gardenerSa, 5*time.Second)).To(Succeed())
 		Expect(testenv.WaitForObjectToBeDeleted(ctx, installation, 5*time.Second)).To(Succeed())
 		Expect(testenv.WaitForObjectToBeDeleted(ctx, context, 5*time.Second)).To(Succeed())
 	})

--- a/pkg/controllers/instances/reconcile_test.go
+++ b/pkg/controllers/instances/reconcile_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Reconcile", func() {
 
 		target := &lsv1alpha1.Target{}
 		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: instance.Status.TargetRef.Name, Namespace: instance.Status.TargetRef.Namespace}, target)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: instance.Status.GardenerServiceAccountRef.Name, Namespace: instance.Status.GardenerServiceAccountRef.Namespace}, target)).To(Succeed())
 
 		installation := &lsv1alpha1.Installation{}
 		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: instance.Status.InstallationRef.Name, Namespace: instance.Status.InstallationRef.Namespace}, installation)).To(Succeed())

--- a/pkg/controllers/instances/testdata/delete/test3/gardener-sa-target.yaml
+++ b/pkg/controllers/instances/testdata/delete/test3/gardener-sa-target.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2021 "SAP SE or an SAP affiliate company and Gardener contributors"
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: landscaper.gardener.cloud/v1alpha1
+kind: Target
+metadata:
+  name: test-gardener-sa
+  namespace: {{ .Namespace }}
+spec:
+  type: landscaper.gardener.cloud/kubernetes-cluster
+  config:
+    kubeconfig: |
+      abcdefg

--- a/pkg/controllers/instances/testdata/delete/test3/instance.yaml
+++ b/pkg/controllers/instances/testdata/delete/test3/instance.yaml
@@ -27,6 +27,10 @@ status:
       name: test
       namespace: {{ .Namespace }}
 
+    gardenerServiceAccountRef:
+      name: test-gardener-sa
+      namespace: {{ .Namespace }}
+
     contextRef:
       name: test
       namespace: {{ .Namespace }}

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
@@ -129,6 +129,19 @@ spec:
                 required:
                 - name
                 type: object
+              gardenerServiceAccountRef:
+                description: GardenerServiceAccountRef references the Target for the
+                  Gardener service account.
+                properties:
+                  name:
+                    description: Name is the name of the kubernetes object.
+                    type: string
+                  namespace:
+                    description: Namespace is the namespace of kubernetes object.
+                    type: string
+                required:
+                - name
+                type: object
               installationRef:
                 description: InstallationRef references the Installation for this
                   Instance.


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously there was a shared gardener service account target created for all instances in a namespace.
This doesn't work since the LAAS controller tries to re-set the owner-reference when a new instance in the same namespace is created.

Whit this change, a dedicated gardener service account target is created for each instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Create a dedicated gardener service account target for each instance.
```
