### PR TITLE
enable automic reconcile for failed landscaper instance installations

### DIFF
--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -52,6 +52,8 @@ const (
 	// automaticReconcileSeconds is the number of seconds after which installations of landscaper instances are
 	// automatically reconciled. Important: the value must be shorter than tokenExpirationSeconds
 	automaticReconcileSeconds = 14 * 24 * 60 * 60
+	// failedReconcileSeconds is the number of seconds after which a failed landscaper instance is automatically reconciled.
+	failedReconcileSeconds = 60 * 10
 	// tokenExpirationSeconds defines how long the tokens are valid	which the landscaper and sidecar controllers use
 	// to access the resource cluster, e.g. for watching installations, namespace registrations etc.
 	// Important: the value must be larger than automaticReconcileSeconds.
@@ -499,6 +501,9 @@ func (c *Controller) mutateInstallation(ctx context.Context, installation *lsv1a
 		AutomaticReconcile: &lsv1alpha1.AutomaticReconcile{
 			SucceededReconcile: &lsv1alpha1.SucceededReconcile{
 				Interval: &lsv1alpha1.Duration{Duration: time.Duration(automaticReconcileSeconds) * time.Second},
+			},
+			FailedReconcile: &lsv1alpha1.FailedReconcile{
+				Interval: &lsv1alpha1.Duration{Duration: time.Duration(failedReconcileSeconds) * time.Second},
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable automatic reconcile for failed landscaper instance installations which is set to 10 minutes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Enable automatic reconcile for failed landscaper instance installations.
```
