### PR TITLE
set high availability config for instances

### DIFF
--- a/pkg/controllers/landscaperdeployments/reconcile.go
+++ b/pkg/controllers/landscaperdeployments/reconcile.go
@@ -134,6 +134,7 @@ func (c *Controller) mutateInstance(ctx context.Context, deployment *lssv1alpha1
 	instance.Spec.TenantId = deployment.Spec.TenantId
 	instance.Spec.LandscaperConfiguration = deployment.Spec.LandscaperConfiguration
 	instance.Spec.OIDCConfig = deployment.Spec.OIDCConfig
+	instance.Spec.HighAvailabilityConfig = deployment.Spec.HighAvailabilityConfig
 
 	c.Operation.Scheme().Default(instance)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The deployment controller needs to set the high availability configuration for the instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Fix missing high availability config for instances.
```
