### PR TITLE
dont cache the gardener service account client

### DIFF
--- a/pkg/controllers/instances/controller.go
+++ b/pkg/controllers/instances/controller.go
@@ -37,9 +37,8 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 // Controller is the instances controller
 type Controller struct {
 	operation.Operation
-	log                          logging.Logger
-	gardenerServiceAccountClient client.Client
-	reconcileHelper              *automaticReconcileHelper
+	log             logging.Logger
+	reconcileHelper *automaticReconcileHelper
 
 	UniqueIDFunc func() string
 
@@ -96,12 +95,11 @@ func (t *TestKubeClientExtractor) GetKubeClientFromServiceTargetConfig(_ context
 // NewTestActuator creates a new controller for testing purposes.
 func NewTestActuator(op operation.Operation, logger logging.Logger) *Controller {
 	ctrl := &Controller{
-		Operation:                    op,
-		log:                          logger,
-		UniqueIDFunc:                 defaultUniqueIdFunc,
-		gardenerServiceAccountClient: op.Client(),
-		reconcileHelper:              newAutomaticReconcileHelper(op.Client(), clock.RealClock{}),
-		kubeClientExtractor:          &TestKubeClientExtractor{},
+		Operation:           op,
+		log:                 logger,
+		UniqueIDFunc:        defaultUniqueIdFunc,
+		reconcileHelper:     newAutomaticReconcileHelper(op.Client(), clock.RealClock{}),
+		kubeClientExtractor: &TestKubeClientExtractor{},
 	}
 	ctrl.ReconcileFunc = ctrl.reconcile
 	ctrl.HandleDeleteFunc = ctrl.handleDelete

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -690,10 +690,6 @@ func (c *Controller) listShoots(ctx context.Context, instance *lssv1alpha1.Insta
 
 // getGardenerServiceAccountClient retrieves and initializes the gardener service account client, if necessary.
 func (c *Controller) getGardenerServiceAccountClient(ctx context.Context) (client.Client, error) {
-	if c.gardenerServiceAccountClient != nil {
-		return c.gardenerServiceAccountClient, nil
-	}
-
 	gardenerServiceAccountSecret := &corev1.Secret{}
 	if err := c.Client().Get(ctx, c.Config().GardenerConfiguration.ServiceAccountKubeconfig.NamespacedName(), gardenerServiceAccountSecret); err != nil {
 		return nil, fmt.Errorf("failed to load gardener service account secret: %w", err)
@@ -723,6 +719,5 @@ func (c *Controller) getGardenerServiceAccountClient(ctx context.Context) (clien
 		return nil, fmt.Errorf("failed to create client for gardener service account: %w", err)
 	}
 
-	c.gardenerServiceAccountClient = saClient
 	return saClient, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't cache the gardener service account client because the secret containing the service account may have changed while the controller is running.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Don't cache the gardener service account client.
```
