### PR TITLE
Update to golang:1.19.8

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -27,7 +27,7 @@ landscaper-service:
             image: eu.gcr.io/gardener-project/landscaper-service/landscaper-service-target-shoot-sidecar-server
     steps:
       verify:
-        image: 'golang:1.19.6'
+        image: 'golang:1.19.8'
       publish-helm-charts:
         depends:
         - verify

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -39,7 +39,7 @@ landscaper-service:
           depends:
             - publish
             - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.8-alpine3.17'
           execute:
             - "integration_test"
           output_dir: 'integration_test'
@@ -60,7 +60,7 @@ landscaper-service:
           depends: 
           - publish
           - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.8-alpine3.17'
           execute:
           - "integration_test_pr"
           output_dir: 'integration_test'
@@ -88,7 +88,7 @@ landscaper-service:
           depends:
             - publish
             - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.6-alpine3.16'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.8-alpine3.17'
           execute:
             - "integration_test"
           output_dir: 'integration_test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### BUILDER ####
-FROM golang:1.19.6 AS builder
+FROM golang:1.19.8 AS builder
 
 WORKDIR /go/src/github.com/gardener/landscaper-service
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,8 @@ helm-charts:
 
 .PHONY: build-resources
 build-resources: docker-all helm-charts cnudie
+
+.PHONY: build-int-test-image
+build-int-test-image:
+	@docker build integration-test/docker -t eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.8-alpine3.17
+	@docker push eu.gcr.io/gardener-project/landscaper-service/integration-test:1.19.8-alpine3.17

--- a/integration-test/docker/Dockerfile
+++ b/integration-test/docker/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.19.6-alpine3.16
+FROM golang:1.19.8-alpine3.17
 
 RUN apk add --no-cache --no-progress \
     bash \


### PR DESCRIPTION
**What this PR does / why we need it**:
Update to golang 1.19.8 removes [CVE-2023-24538](https://nvd.nist.gov/vuln/detail/CVE-2023-24538)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Update to golang 1.19.8 eliminates CVE-2023-24538
```
