### PR TITLE
dynamic export names

### DIFF
--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/installation/installation.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/installation/installation.go
@@ -6,6 +6,10 @@ package installation
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
+
+	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
@@ -202,4 +206,11 @@ func toAnyJSON(obj any) (*lsv1alpha1.AnyJSON, error) {
 	}
 	anyJSON := lsv1alpha1.NewAnyJSON(raw)
 	return &anyJSON, err
+}
+
+// GetInstallationExportDataRef returns the export data ref that is dynamically created based on the instance name.
+// The data ref string is compatible to be used as a kubernetes object name.
+func GetInstallationExportDataRef(instance *lssv1alpha1.Instance, exportName string) string {
+	dataRef := fmt.Sprintf("%s-%s", strings.ToLower(exportName), instance.GetName())
+	return dataRef
 }

--- a/pkg/apis/installation/installation.go
+++ b/pkg/apis/installation/installation.go
@@ -6,6 +6,10 @@ package installation
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
+
+	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 
@@ -202,4 +206,11 @@ func toAnyJSON(obj any) (*lsv1alpha1.AnyJSON, error) {
 	}
 	anyJSON := lsv1alpha1.NewAnyJSON(raw)
 	return &anyJSON, err
+}
+
+// GetInstallationExportDataRef returns the export data ref that is dynamically created based on the instance name.
+// The data ref string is compatible to be used as a kubernetes object name.
+func GetInstallationExportDataRef(instance *lssv1alpha1.Instance, exportName string) string {
+	dataRef := fmt.Sprintf("%s-%s", strings.ToLower(exportName), instance.GetName())
+	return dataRef
 }

--- a/pkg/controllers/instances/reconcile_test.go
+++ b/pkg/controllers/instances/reconcile_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Reconcile", func() {
 				Name:      "endpointexport",
 				Namespace: state.Namespace,
 				Labels: map[string]string{
-					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.ClusterEndpointExportName,
+					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.GetInstallationExportDataRef(instance, lsinstallation.ClusterEndpointExportName),
 					lsv1alpha1.DataObjectSourceLabel:     fmt.Sprintf("Inst.%s", installation.Name),
 					lsv1alpha1.DataObjectSourceTypeLabel: string(lsv1alpha1.ExportDataObjectSourceType),
 				},
@@ -168,7 +168,7 @@ var _ = Describe("Reconcile", func() {
 				Name:      "userkubeconfigexport",
 				Namespace: state.Namespace,
 				Labels: map[string]string{
-					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.UserKubeconfigExportName,
+					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.GetInstallationExportDataRef(instance, lsinstallation.UserKubeconfigExportName),
 					lsv1alpha1.DataObjectSourceLabel:     fmt.Sprintf("Inst.%s", installation.Name),
 					lsv1alpha1.DataObjectSourceTypeLabel: string(lsv1alpha1.ExportDataObjectSourceType),
 				},
@@ -183,7 +183,7 @@ var _ = Describe("Reconcile", func() {
 				Name:      "adminkubeconfigexport",
 				Namespace: state.Namespace,
 				Labels: map[string]string{
-					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.AdminKubeconfigExportName,
+					lsv1alpha1.DataObjectKeyLabel:        lsinstallation.GetInstallationExportDataRef(instance, lsinstallation.AdminKubeconfigExportName),
 					lsv1alpha1.DataObjectSourceLabel:     fmt.Sprintf("Inst.%s", installation.Name),
 					lsv1alpha1.DataObjectSourceTypeLabel: string(lsv1alpha1.ExportDataObjectSourceType),
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

When creating multiple landscaper deployments for a single tenant, multiple landscaper-instance installations are created in a single namespace.
Therefore the export names of the landscaper-instance installations must be unique for each installation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator.
Use unique lnadscaper-instance installation export names.
```
