### PR TITLE
Reduces the info logs and reconcile loops for instances

### DIFF
--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -381,7 +381,12 @@ func (c *Controller) reconcileInstallation(ctx context.Context, instance *lssv1a
 		return err
 	}
 
+	// we must prevent to update only because of a new date
+	newAutomaticReconcileStatus := instance.Status.AutomaticReconcileStatus
+	instance.Status.AutomaticReconcileStatus = old.Status.AutomaticReconcileStatus
+
 	if !reflect.DeepEqual(old.Status, instance.Status) {
+		instance.Status.AutomaticReconcileStatus = newAutomaticReconcileStatus
 		if err := c.Client().Status().Update(ctx, instance); err != nil {
 			return fmt.Errorf("unable to update instance status: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR reduces the the info logs and reconcile loops for instances. Instance status is not updated anymore if only the last reconcile date has changed resulting in more than 400.000 log entries and corresponding reconcile loops for the last 24 hours of our live landscape.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- reduces the info logs and reconcile loops for instances
```
