### PR TITLE
new manual component descriptor logic

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -8,7 +8,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "create dummy component descriptor"
+echo "create dummy component descriptor BEGIN"
 
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
@@ -17,6 +17,10 @@ COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}"
 
 VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py
 
-echo "create real component descriptor"
+echo "create dummy component descriptor END"
+
+echo "create real component descriptor BEGIN"
 
 ${SOURCE_PATH}/.ci/component_descriptor_real
+
+echo "create real component descriptor END"

--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,87 +8,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "component-cli is required to generate the component descriptors"
-CLI_PATH="$(mktemp -d)"
-COMP_CLI=${CLI_PATH}/component-cli
-echo "Trying to installing component-cli to ${COMP_CLI}"
-curl -L https://github.com/gardener/component-cli/releases/download/v0.48.0/componentcli-linux-amd64.gz | gzip -d > ${COMP_CLI}
-chmod +x ${COMP_CLI}
+echo "create dummy component descriptor"
 
 SOURCE_PATH="$(dirname $0)/.."
 VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
-COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
-REPO_CTX="${CURRENT_COMPONENT_REPOSITORY}"
+REPO_CTX="eu.gcr.io/gardener-project/development"
+COMPONENT_DESCRIPTOR_DIR="${SOURCE_PATH}/../${COMPONENT_DESCRIPTOR_DIR}"
 
-printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
+VERSION="${VERSION}-dummy" REPO_CTX="${REPO_CTX}" COMPONENT_DESCRIPTOR_DIR="${COMPONENT_DESCRIPTOR_DIR}" python ${SOURCE_PATH}/hack/create-dummy-cd.py
 
-function buildResourcesArgs()  {
-  PATH=$1
-  FILES=$2
-  RESOURCES=""
+echo "create real component descriptor"
 
-  for file in $FILES; do
-    if [[ -z $RESOURCES ]]; then
-      RESOURCES+="-r ${PATH}/$file"
-    else
-      RESOURCES+=" -r ${PATH}/$file"
-    fi
-  done
-
-  echo $RESOURCES
-}
-
-function buildComponentArchive() {
-  COMPONENT_NAME=$1
-  RESOURCES=$2
-  CA_PATH="$(mktemp -d)"
-  printf "> Building component ${COMPONENT_NAME}\n"
-
-  COMPONENT_REFERENCES=""
-
-  if [ -f ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml ]; then
-    COMPONENT_REFERENCES="-c ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml"
-  fi
-
-  RESOURCES_ARGS=$(buildResourcesArgs "${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}" "${RESOURCES}")
-
-  ${COMP_CLI} ca "${CA_PATH}" "${CTF_PATH}" \
-    --component-name=github.com/gardener/landscaper-service/${COMPONENT_NAME} \
-    --component-version=${VERSION} \
-    --repo-ctx=${REPO_CTX} \
-    -s ${SOURCE_PATH}/.landscaper/sources.yaml \
-    ${RESOURCES_ARGS} \
-    COMMIT_SHA=${COMMIT_SHA} \
-    VERSION=${VERSION} \
-    $COMPONENT_REFERENCES
-}
-
-buildComponentArchive "logging-stack" "resources.yaml resources-cert-manager.yaml resources-sap-btp-service-operator.yaml resources-fluentbit.yaml"
-buildComponentArchive "ingress-controller" "resources.yaml"
-buildComponentArchive "landscaper-instance" "resources.yaml"
-
-# add landscaper component descriptor
-printf "> Create Landscaper Service ca archive\n"
-LS_CA_PATH="$(mktemp -d)"
-cp ${BASE_DEFINITION_PATH} "${LS_CA_PATH}/component-descriptor.yaml"
-
-printf "> add resources\n"
-${COMP_CLI} ca resources add ${LS_CA_PATH} \
-    VERSION=${VERSION} \
-    ${SOURCE_PATH}/.landscaper/resources.yaml
-
-printf "> add component references\n"
-${COMP_CLI} ca component-references add ${LS_CA_PATH} \
-    VERSION=${VERSION} \
-    ${SOURCE_PATH}/.landscaper/component-references.yaml
-
-cat ${LS_CA_PATH}/component-descriptor.yaml
-
-printf "> Add Landscaper Service CA to ctf\n"
-${COMP_CLI} ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
-
-# also upload the components to a open source repo
-# todo: remove as soon as the default component repository is public
-${COMP_CLI} ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"
-
-echo "END component_descriptor script"
+${SOURCE_PATH}/.ci/component_descriptor_real

--- a/.ci/component_descriptor_real
+++ b/.ci/component_descriptor_real
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "component-cli is required to generate the component descriptors"
+CLI_PATH="$(mktemp -d)"
+COMP_CLI=${CLI_PATH}/component-cli
+echo "Trying to installing component-cli to ${COMP_CLI}"
+OS="$(uname -o | awk '{print tolower($0)}')"
+ARCH="$(uname -m | awk '{print tolower($0)}')"
+
+if [[ ${OS} == *"linux"* ]]; then
+  OS="linux"
+fi
+if [[ ${OS} == *"darwin"* ]]; then
+  OS="darwin"
+fi
+
+if [[ ${ARCH} == *"x86_64"* ]]; then
+  ARCH="amd64"
+fi
+if [[ ${ARCH} == *"arm64"* ]]; then
+  ARCH="arm64"
+fi
+if [[ ${ARCH} == *"aarch64"* ]]; then
+  ARCH="arm64"
+fi
+
+curl -L https://github.com/gardener/component-cli/releases/download/v0.55.0/componentcli-${OS}-${ARCH}.gz | gzip -d > ${COMP_CLI}
+chmod +x ${COMP_CLI}
+
+SOURCE_PATH="$(dirname $0)/.."
+VERSION="$(${SOURCE_PATH}/hack/get-version.sh)"
+COMMIT_SHA="$(git --git-dir ${SOURCE_PATH}/.git rev-parse HEAD)"
+
+printf "> Building components with version ${VERSION} - ${COMMIT_SHA}\n"
+
+REPO_CTX="eu.gcr.io/sap-gcp-cp-k8s-stable-hub/landscaper"
+REPO_CTX_DEV="eu.gcr.io/gardener-project/development"
+CTF_PATH="$(mktemp -d)"
+CTF_PATH="${CTF_PATH}/ctf.tar"
+
+function buildResourcesArgs()  {
+  PATH=$1
+  FILES=$2
+  RESOURCES=""
+
+  for file in $FILES; do
+    if [[ -z $RESOURCES ]]; then
+      RESOURCES+="-r ${PATH}/$file"
+    else
+      RESOURCES+=" -r ${PATH}/$file"
+    fi
+  done
+
+  echo $RESOURCES
+}
+
+function buildComponentArchive() {
+  COMPONENT_NAME=$1
+  RESOURCES=$2
+  CA_PATH="$(mktemp -d)"
+  printf "> Building component ${COMPONENT_NAME}\n"
+
+  COMPONENT_REFERENCES=""
+
+  if [ -f ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml ]; then
+    COMPONENT_REFERENCES="-c ${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}/component-references.yaml"
+  fi
+
+  RESOURCES_ARGS=$(buildResourcesArgs "${SOURCE_PATH}/.landscaper/${COMPONENT_NAME}" "${RESOURCES}")
+
+  ${COMP_CLI} ca "${CA_PATH}" "${CTF_PATH}" \
+    --component-name=github.com/gardener/landscaper-service/${COMPONENT_NAME} \
+    --component-version=${VERSION} \
+    --repo-ctx=${REPO_CTX} \
+    -s ${SOURCE_PATH}/.landscaper/sources.yaml \
+    ${RESOURCES_ARGS} \
+    COMMIT_SHA=${COMMIT_SHA} \
+    VERSION=${VERSION} \
+    $COMPONENT_REFERENCES
+}
+
+buildComponentArchive "logging-stack" "resources.yaml resources-cert-manager.yaml resources-sap-btp-service-operator.yaml resources-fluentbit.yaml"
+buildComponentArchive "ingress-controller" "resources.yaml"
+buildComponentArchive "landscaper-instance" "resources.yaml"
+
+# add landscaper component descriptor
+printf "> Create Landscaper Service Component"
+LS_CA_PATH="$(mktemp -d)"
+${COMP_CLI}  ca create "${LS_CA_PATH}" \
+  --component-name=github.com/gardener/landscaper-service \
+  --component-version=${VERSION} \
+  --repo-ctx=${REPO_CTX}
+
+printf "> add resources\n"
+${COMP_CLI} ca resources add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    ${SOURCE_PATH}/.landscaper/resources.yaml
+
+printf "> add component references\n"
+${COMP_CLI} ca component-references add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    ${SOURCE_PATH}/.landscaper/component-references.yaml
+
+printf "> add sources\n"
+${COMP_CLI} ca sources add ${LS_CA_PATH} \
+    VERSION=${VERSION} \
+    COMMIT_SHA=${COMMIT_SHA} \
+    ${SOURCE_PATH}/.landscaper/sources.yaml
+
+cat ${LS_CA_PATH}/component-descriptor.yaml
+
+printf "> Add Landscaper Service CA to ctf\n"
+${COMP_CLI} ctf add "${CTF_PATH}" -f "${LS_CA_PATH}"
+
+printf "> Publish Landscaper Service Components to ${REPO_CTX}\n"
+${COMP_CLI} ctf push --repo-ctx=${REPO_CTX} "${CTF_PATH}"
+
+printf "> Publish Landscaper Components to ${REPO_CTX_DEV}\n"
+${COMP_CLI} ctf push --repo-ctx=${REPO_CTX_DEV} "${CTF_PATH}"

--- a/.landscaper/resources.yaml
+++ b/.landscaper/resources.yaml
@@ -16,3 +16,27 @@ input:
   mediaType: application/vnd.gardener.landscaper.blueprint.layer.v1.tar+gzip
   compress: true
 ...
+---
+type: ociImage
+name: landscaper-service-controller
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper-service/landscaper-service-controller:${VERSION}
+...
+---
+type: ociImage
+name: landscaper-service-webhooks-server
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper-service/landscaper-service-webhooks-server:${VERSION}
+...
+---
+type: ociImage
+name: landscaper-service-target-shoot-sidecar-server
+relation: local
+access:
+  type: ociRegistry
+  imageReference: eu.gcr.io/gardener-project/landscaper-service/landscaper-service-target-shoot-sidecar-server:${VERSION}
+...

--- a/hack/create-dummy-cd.py
+++ b/hack/create-dummy-cd.py
@@ -1,0 +1,17 @@
+import os
+import yaml
+
+version = os.environ["VERSION"]
+repo_ctx = os.environ["REPO_CTX"]
+component_descriptor_dir = os.environ["COMPONENT_DESCRIPTOR_DIR"]
+
+cd = None
+
+with open(os.path.join(component_descriptor_dir, "base_component_descriptor_v2"), "r") as base_cd_file:
+    cd = yaml.safe_load(base_cd_file.read())
+
+cd["component"]["version"] = version
+cd["component"]["repositoryContexts"][0]["baseUrl"] = repo_ctx
+
+with open(os.path.join(component_descriptor_dir, "component_descriptor_v2"), "w+") as cd_file:
+    cd_file.write(yaml.safe_dump(cd))


### PR DESCRIPTION
**What this PR does / why we need it**:

Since landscaper service is still using component-cli, this PR uses its own component upload logic instead of the implicit functionality of the CICD pipeline tools.

The implicit pipeline logic will now upload a dummy component with a version ending with "-dummy".
This is done because the pipeline relies on this component to create a release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
