### PR TITLE
disable cache in uncached client

### DIFF
--- a/pkg/utils/uncached_client.go
+++ b/pkg/utils/uncached_client.go
@@ -6,6 +6,8 @@ import (
 )
 
 func NewUncachedClient(config *rest.Config, options client.Options) (client.Client, error) {
+	options.Cache = nil
+
 	c, err := client.New(config, options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

With the update of the controller runtime the disabling of the client cache was lost.
This change disables the client cache again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Disable kubernetes client cache.
```
