### PR TITLE
enforce KeyResource values to be of type string

### DIFF
--- a/pkg/controllers/instances/reconcile_delete.go
+++ b/pkg/controllers/instances/reconcile_delete.go
@@ -126,7 +126,7 @@ func (c *Controller) ensureDeleteInstallationForInstance(ctx context.Context, in
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(instance).String()},
 		lc.KeyMethod, "ensureDeleteInstallationForInstance")
 
-	logger.Info("Delete installation for instance", lc.KeyResource, instance.Status.InstallationRef.NamespacedName())
+	logger.Info("Delete installation for instance", lc.KeyResource, instance.Status.InstallationRef.NamespacedName().String())
 	installation := &lsv1alpha1.Installation{}
 
 	if err := c.Client().Get(ctx, instance.Status.InstallationRef.NamespacedName(), installation); err != nil {
@@ -155,7 +155,7 @@ func (c *Controller) ensureDeleteTargetForInstance(ctx context.Context, instance
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(instance).String()},
 		lc.KeyMethod, "ensureDeleteTargetForInstance")
 
-	logger.Info("Delete target for instance", lc.KeyResource, instance.Status.TargetRef.NamespacedName())
+	logger.Info("Delete target for instance", lc.KeyResource, instance.Status.TargetRef.NamespacedName().String())
 	target := &lsv1alpha1.Target{}
 
 	if err := c.Client().Get(ctx, instance.Status.TargetRef.NamespacedName(), target); err != nil {
@@ -184,7 +184,7 @@ func (c *Controller) ensureDeleteGardenerServiceAccountTargetForInstance(ctx con
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(instance).String()},
 		lc.KeyMethod, "ensureDeleteGardenerServiceAccountTargetForInstance")
 
-	logger.Info("Delete gardener service account target for instance", lc.KeyResource, instance.Status.GardenerServiceAccountRef.NamespacedName())
+	logger.Info("Delete gardener service account target for instance", lc.KeyResource, instance.Status.GardenerServiceAccountRef.NamespacedName().String())
 	target := &lsv1alpha1.Target{}
 
 	if err := c.Client().Get(ctx, instance.Status.GardenerServiceAccountRef.NamespacedName(), target); err != nil {
@@ -213,7 +213,7 @@ func (c *Controller) ensureDeleteContextForInstance(ctx context.Context, instanc
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(instance).String()},
 		lc.KeyMethod, "ensureDeleteContextForInstance")
 
-	logger.Info("Delete context for instance", lc.KeyResource, instance.Status.ContextRef.NamespacedName())
+	logger.Info("Delete context for instance", lc.KeyResource, instance.Status.ContextRef.NamespacedName().String())
 	landscaperContext := &lsv1alpha1.Context{}
 
 	if err := c.Client().Get(ctx, instance.Status.ContextRef.NamespacedName(), landscaperContext); err != nil {

--- a/pkg/controllers/landscaperdeployments/reconcile_delete.go
+++ b/pkg/controllers/landscaperdeployments/reconcile_delete.go
@@ -51,7 +51,7 @@ func (c *Controller) ensureDeleteInstanceForDeployment(ctx context.Context, depl
 	logger, ctx := logging.FromContextOrNew(ctx, []interface{}{lc.KeyReconciledResource, client.ObjectKeyFromObject(deployment).String()},
 		lc.KeyMethod, "ensureDeleteInstanceForDeployment")
 
-	logger.Info("Delete instance for landscaper deployment", lc.KeyResource, deployment.Status.InstanceRef.NamespacedName())
+	logger.Info("Delete instance for landscaper deployment", lc.KeyResource, deployment.Status.InstanceRef.NamespacedName().String())
 	instance := &lssv1alpha1.Instance{}
 
 	if err := c.Client().Get(ctx, deployment.Status.InstanceRef.NamespacedName(), instance); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Logging parameter types must be consistent. There have been some logs where the KeyResource value was not of type string.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
enforce KeyResource values to be of type string
```
