### PR TITLE
Fix namespaceregistration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ format:
 	@$(REPO_ROOT)/hack/format.sh $(REPO_ROOT)/pkg $(REPO_ROOT)/cmd $(REPO_ROOT)/hack $(REPO_ROOT)/test $(REPO_ROOT)/integration-test/pkg
 
 .PHONY: check
-check: revendor
+check: revendor check-fast
+
+.PHONY: check-fast
+check-fast:
 	@$(REPO_ROOT)/hack/check.sh --golangci-lint-config=./.golangci.yaml $(REPO_ROOT)/cmd/... $(REPO_ROOT)/pkg/... $(REPO_ROOT)/hack/... $(REPO_ROOT)/test/...
 	@cd $(REPO_ROOT)/integration-test && $(REPO_ROOT)/hack/check.sh --golangci-lint-config=$(REPO_ROOT)/.golangci.yaml ./pkg/...
 

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -248,21 +248,8 @@ The following image gives a more detailed descriptions of the involved roles, cl
 #### Controlling Customer Namespaces on the Resource-Shoot-Cluster
 
 A user, with access to the Resource-Shoot-Cluster as described before, is only allowed to create Landscaper resources 
-like Installations, Targets etc. in so-called customer namespaces. A customer namespace is a normal namespace on the
-Resource-Shoot-Cluster with a name starting with the prefix *cu-*. 
-
-To create such a namespace the user must create a 
-*[namespaceRegistration](../../pkg/apis/core/v1alpha1/types_namespaceregistration.go)* object in the namespace ls-user
-with the same name as the namespace. The following manifest for example would create a customer namespace *cu-test*:
-
-```yaml
-apiVersion: landscaper-service.gardener.cloud/v1alpha1
-kind: NamespaceRegistration
-metadata:
-  name: cu-test
-  namespace: ls-user
-spec: {}
-```
+like Installations, Targets etc. in so-called customer namespaces. More about customer namespaces could be found
+[here](../usage/Namespaceregistration.md)
 
 The controllers of ls-service-target-shoot-sidecar-server automatically creates the required roles, role-bindings etc. 
 for all entries in the `SubjectList` *subjects* in every newly created customer namespace (see the details in the image 

--- a/docs/usage/Namespaceregistration.md
+++ b/docs/usage/Namespaceregistration.md
@@ -1,0 +1,39 @@
+# Namespaceregistrtion
+
+A user, with access to the Resource-Shoot-Cluster as described before, is only allowed to create Landscaper resources
+like Installations, Targets etc. in so-called customer namespaces. A customer namespace is a normal namespace on the
+Resource-Shoot-Cluster with a name starting with the prefix *cu-*.
+
+## Create a Customer Namespace
+
+To create such a customer namespace the user must create a
+*[namespaceRegistration](../../pkg/apis/core/v1alpha1/types_namespaceregistration.go)* object in the namespace ls-user
+with the same name as the namespace. The following manifest for example would create a customer namespace *cu-test*:
+
+```yaml
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test
+  namespace: ls-user
+spec: {}
+```
+
+If the creation of a customer namespace was successful, the status of the `NamespaceRegistration` looks as follows:
+
+```yaml
+status:
+  phase: Completed
+```
+
+In case of an error you find the corresponding message in the status section.
+
+## Deleting Namespaceregistrations
+
+When deleting a `NamespaceRegistration` the corresponding namespace is deleted. This is executed accoding to the 
+following strategy:
+
+- All root Installations with a "delete-without-uninstall" annotation 
+  ([see](https://github.com/gardener/landscaper/blob/master/docs/usage/Annotations.md#delete-without-uninstall-annotation))
+  are deleted.
+- As long as there are still Install...

--- a/docs/usage/Namespaceregistration.md
+++ b/docs/usage/Namespaceregistration.md
@@ -36,4 +36,13 @@ following strategy:
 - All root Installations with a "delete-without-uninstall" annotation 
   ([see](https://github.com/gardener/landscaper/blob/master/docs/usage/Annotations.md#delete-without-uninstall-annotation))
   are deleted.
-- As long as there are still Install...
+
+- As long as there are still Installations in the namespace, the namespace is not deleted and this is written
+  into the status of the `NamespaceRegistration`. This also means if there are still installations without
+  a "delete-without-uninstall" annotation these have to be deleted by the customer itself. 
+
+- Is there are no Installations in the namespace anymore, all other resources in that namespace are removed and 
+  subsequently the namespace is deleted. If the customer has created resources with a custom finalizer, these have to be
+  removed before deleting a `NamespaceRegistration`. Otherwise, the final deletion might fail and requires manual
+  intervention. It is anyhow no good idea and should be prevented to create resources with custom finalizers in
+  a customer namespace. 

--- a/hack/setup-testenv.sh
+++ b/hack/setup-testenv.sh
@@ -30,7 +30,7 @@ ln -s "${KUBEBUILDER_ASSETS}" ${PROJECT_ROOT}/tmp/test/bin
 LANDSCAPER_APIS_VERSION=$(go list -m -mod=readonly -f {{.Version}}  github.com/gardener/landscaper/apis)
 LANDSCAPER_CRD_URL="https://raw.githubusercontent.com/gardener/landscaper/${LANDSCAPER_APIS_VERSION}/pkg/landscaper/crdmanager/crdresources"
 LANDSCAPER_CRD_DIR="${PROJECT_ROOT}/tmp/landscapercrd"
-LANDSCAPER_CRDS="landscaper.gardener.cloud_installations.yaml landscaper.gardener.cloud_targets.yaml landscaper.gardener.cloud_dataobjects.yaml landscaper.gardener.cloud_contexts.yaml landscaper.gardener.cloud_lshealthchecks.yaml"
+LANDSCAPER_CRDS="landscaper.gardener.cloud_installations.yaml landscaper.gardener.cloud_executions.yaml landscaper.gardener.cloud_deployitems.yaml landscaper.gardener.cloud_targetsyncs.yaml landscaper.gardener.cloud_targets.yaml landscaper.gardener.cloud_dataobjects.yaml landscaper.gardener.cloud_contexts.yaml landscaper.gardener.cloud_lshealthchecks.yaml"
 mkdir -p ${PROJECT_ROOT}/tmp/landscapercrd
 
 for crd in $LANDSCAPER_CRDS; do

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/utils/utils.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -83,4 +85,22 @@ func RemoveOperationAnnotation(object client.Object) {
 	if annotations != nil {
 		delete(annotations, lssv1alpha1.LandscaperServiceOperationAnnotation)
 	}
+}
+
+// HasLabel checks if the objects has a label
+func HasLabel(obj metav1.Object, lab string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[lab]
+	return ok
+}
+
+// HasDeleteWithoutUninstallAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/delete-without-uninstall' annotation
+// and its value is 'true'.
+func HasDeleteWithoutUninstallAnnotation(obj metav1.Object) bool {
+	v, ok := obj.GetAnnotations()[lsv1alpha1.DeleteWithoutUninstallAnnotation]
+	return ok && v == "true"
 }

--- a/pkg/controllers/namespaceregistration/add.go
+++ b/pkg/controllers/namespaceregistration/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -24,8 +25,11 @@ func AddControllerToManager(logger logging.Logger, mgr manager.Manager, config *
 		return err
 	}
 
+	predicates := builder.WithPredicates(predicate.Or(predicate.LabelChangedPredicate{},
+		predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
+
 	return builder.ControllerManagedBy(mgr).
-		For(&v1alpha1.NamespaceRegistration{}).
+		For(&v1alpha1.NamespaceRegistration{}, predicates).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
 		Complete(ctrl)
 }

--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -66,6 +66,8 @@ func NewTestActuator(op operation.TargetShootSidecarOperation, logger logging.Lo
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger, ctx := c.log.StartReconcileAndAddToContext(ctx, req)
 
+	logger.Info("start reconcile namespaceRegistration")
+
 	namespaceRegistration := &lssv1alpha1.NamespaceRegistration{}
 	if err := c.Client().Get(ctx, req.NamespacedName, namespaceRegistration); err != nil {
 		logger.Error(err, "failed loading namespaceregistration cr")

--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -93,7 +93,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err := c.Client().Update(ctx, namespaceRegistration); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	// reconcile delete

--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -187,7 +187,7 @@ func (c *Controller) removeResourcesAndNamespace(ctx context.Context, namespaceR
 			nextTargetSync := &targetSyncs.Items[i]
 			controllerutil.RemoveFinalizer(nextTargetSync, v1alpha1.LandscaperFinalizer)
 
-			if err := c.Client().Status().Update(ctx, nextTargetSync); err != nil {
+			if err := c.Client().Update(ctx, nextTargetSync); err != nil {
 				return c.logAndUpdate(ctx, err, namespaceRegistration, "Failed Removing Finalizer Of TargetSync")
 			}
 

--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -185,16 +185,12 @@ func (c *Controller) removeResourcesAndNamespace(ctx context.Context, namespaceR
 	if len(targetSyncs.Items) > 0 {
 		for i := range targetSyncs.Items {
 			nextTargetSync := &targetSyncs.Items[i]
-			controllerutil.RemoveFinalizer(nextTargetSync, v1alpha1.LandscaperFinalizer)
-
-			if err := c.Client().Update(ctx, nextTargetSync); err != nil {
-				return c.logAndUpdate(ctx, err, namespaceRegistration, "Failed Removing Finalizer Of TargetSync")
-			}
-
 			if err := c.Client().Delete(ctx, nextTargetSync); err != nil {
 				return c.logAndUpdate(ctx, err, namespaceRegistration, "Failed Removing TargetSync")
 			}
 		}
+
+		return c.logAndUpdate(ctx, nil, namespaceRegistration, "Namespace Contains TargetSyncs")
 	}
 
 	return c.removeAccessDataAndNamespace(ctx, namespaceRegistration, namespace)

--- a/pkg/controllers/namespaceregistration/controller.go
+++ b/pkg/controllers/namespaceregistration/controller.go
@@ -93,7 +93,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err := c.Client().Update(ctx, namespaceRegistration); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+		// do not return here because the controller only watches for particular events and setting a finalizer is not part of this
 	}
 
 	// reconcile delete

--- a/pkg/controllers/namespaceregistration/reconcile_test.go
+++ b/pkg/controllers/namespaceregistration/reconcile_test.go
@@ -8,16 +8,23 @@ import (
 	"context"
 	"time"
 
+	"github.com/gardener/landscaper/apis/core/v1alpha1/helper"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	lssv1alpha1 "github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 	"github.com/gardener/landscaper-service/pkg/controllers/namespaceregistration"
 	"github.com/gardener/landscaper-service/pkg/controllers/subjectsync"
 	"github.com/gardener/landscaper-service/pkg/operation"
@@ -132,6 +139,248 @@ var _ = Describe("Reconcile", func() {
 		// deletion
 		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
 		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
+
+		// check for namespace being deleted
+		Expect(namespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
+	})
+
+	It("should delete namespace with installation", func() {
+		var err error
+
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test3")
+		Expect(err).ToNot(HaveOccurred())
+
+		namespaceRegistration := state.GetNamespaceRegistration(subjectsync.CUSTOM_NS_PREFIX + "test-namespace-3")
+		//reconcile for finalizer
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		//reconcile for actual run
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(namespaceRegistration), namespaceRegistration)).To(Succeed())
+		Expect(namespaceRegistration.Status.Phase).To(Equal("Completed"))
+
+		// check for namespace being created
+		namespace := corev1.Namespace{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+
+		// add Installation to prevent delete
+		compRef := &lsv1alpha1.ComponentDescriptorDefinition{
+			Reference: &lsv1alpha1.ComponentDescriptorReference{
+				ComponentName: "component",
+				Version:       "v0.1.0",
+			},
+		}
+
+		installation := &lsv1alpha1.Installation{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name, Namespace: namespace.Name},
+			Spec: lsv1alpha1.InstallationSpec{
+				ComponentDescriptor: compRef,
+			},
+		}
+
+		Expect(testenv.Client.Create(ctx, installation)).To(Succeed())
+
+		// delete
+		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+
+		// failed deletion
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+		Expect(namespace.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		// successful deletion
+		Expect(testenv.Client.Delete(ctx, installation)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
+
+		// check for namespace being deleted
+		Expect(namespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
+	})
+
+	It("should delete namespace with execution", func() {
+		var err error
+
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test4")
+		Expect(err).ToNot(HaveOccurred())
+
+		namespaceRegistration := state.GetNamespaceRegistration(subjectsync.CUSTOM_NS_PREFIX + "test-namespace-4")
+		//reconcile for finalizer
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		//reconcile for actual run
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(namespaceRegistration), namespaceRegistration)).To(Succeed())
+		Expect(namespaceRegistration.Status.Phase).To(Equal("Completed"))
+
+		// check for namespace being created
+		namespace := corev1.Namespace{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+
+		// add execution to prevent delete
+		execution := &lsv1alpha1.Execution{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name, Namespace: namespace.Name},
+		}
+
+		Expect(testenv.Client.Create(ctx, execution)).To(Succeed())
+
+		// delete
+		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+
+		// failed deletion
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+		Expect(namespace.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		// successful deletion
+		Expect(testenv.Client.Delete(ctx, execution)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
+
+		// check for namespace being deleted
+		Expect(namespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
+	})
+
+	It("should delete namespace with deploy item", func() {
+		var err error
+
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test5")
+		Expect(err).ToNot(HaveOccurred())
+
+		namespaceRegistration := state.GetNamespaceRegistration(subjectsync.CUSTOM_NS_PREFIX + "test-namespace-5")
+		//reconcile for finalizer
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		//reconcile for actual run
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(namespaceRegistration), namespaceRegistration)).To(Succeed())
+		Expect(namespaceRegistration.Status.Phase).To(Equal("Completed"))
+
+		// check for namespace being created
+		namespace := corev1.Namespace{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+
+		// add execution to prevent delete
+		di := &lsv1alpha1.DeployItem{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name, Namespace: namespace.Name},
+		}
+
+		Expect(testenv.Client.Create(ctx, di)).To(Succeed())
+
+		// delete
+		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+
+		// failed deletion
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+		Expect(namespace.DeletionTimestamp.IsZero()).To(BeTrue())
+
+		// successful deletion
+		Expect(testenv.Client.Delete(ctx, di)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
+
+		// check for namespace being deleted
+		Expect(namespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
+	})
+
+	It("should delete namespace with target sync", func() {
+		var err error
+
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test6")
+		Expect(err).ToNot(HaveOccurred())
+
+		namespaceRegistration := state.GetNamespaceRegistration(subjectsync.CUSTOM_NS_PREFIX + "test-namespace-6")
+		//reconcile for finalizer
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		//reconcile for actual run
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(namespaceRegistration), namespaceRegistration)).To(Succeed())
+		Expect(namespaceRegistration.Status.Phase).To(Equal("Completed"))
+
+		// check for namespace being created
+		namespace := corev1.Namespace{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+
+		// add execution to prevent delete
+		targetSync := &lsv1alpha1.TargetSync{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name, Namespace: namespace.Name},
+		}
+
+		controllerutil.AddFinalizer(targetSync, lsv1alpha1.LandscaperFinalizer)
+
+		Expect(testenv.Client.Create(ctx, targetSync)).To(Succeed())
+
+		targetSync = &lsv1alpha1.TargetSync{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name + "-2", Namespace: namespace.Name},
+		}
+
+		Expect(testenv.Client.Create(ctx, targetSync)).To(Succeed())
+
+		// delete
+		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+
+		// successful deletion
+		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
+
+		// check for namespace being deleted
+		Expect(namespace.Status.Phase).To(Equal(corev1.NamespaceTerminating))
+	})
+
+	It("should delete namespace with installation without uninstall", func() {
+		var err error
+
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test7")
+		Expect(err).ToNot(HaveOccurred())
+
+		namespaceRegistration := state.GetNamespaceRegistration(subjectsync.CUSTOM_NS_PREFIX + "test-namespace-7")
+		//reconcile for finalizer
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		//reconcile for actual run
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(namespaceRegistration), namespaceRegistration)).To(Succeed())
+		Expect(namespaceRegistration.Status.Phase).To(Equal("Completed"))
+
+		// check for namespace being created
+		namespace := corev1.Namespace{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: namespaceRegistration.Name}, &namespace)).To(Succeed())
+
+		// add execution to prevent delete
+		inst := &lsv1alpha1.Installation{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{Name: namespace.Name, Namespace: namespace.Name},
+		}
+
+		metav1.SetMetaDataAnnotation(&inst.ObjectMeta, lsv1alpha1.DeleteWithoutUninstallAnnotation, "true")
+		controllerutil.AddFinalizer(inst, lsv1alpha1.LandscaperFinalizer)
+		Expect(testenv.Client.Create(ctx, inst)).To(Succeed())
+
+		// delete
+		Expect(testenv.Client.Delete(ctx, namespaceRegistration)).To(Succeed())
+
+		// delete installations
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst)).To(Succeed())
+		Expect(inst.GetDeletionTimestamp().IsZero()).ToNot(BeTrue())
+		Expect(helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation)).ToNot(BeTrue())
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(inst), inst)).To(Succeed())
+		Expect(helper.HasOperation(inst.ObjectMeta, lsv1alpha1.ReconcileOperation)).To(BeTrue())
+
+		controllerutil.RemoveFinalizer(inst, lsv1alpha1.LandscaperFinalizer)
+		Expect(testenv.Client.Update(ctx, inst)).To(Succeed())
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(namespaceRegistration))
+
+		// successful deletion
 		Expect(testenv.WaitForObjectToBeDeleted(ctx, testenv.Client, namespaceRegistration, 5*time.Second)).To(Succeed())
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(&namespace), &namespace)).To(Succeed())
 

--- a/pkg/controllers/namespaceregistration/testdata/reconcile/test3/namespaceregistration.yaml
+++ b/pkg/controllers/namespaceregistration/testdata/reconcile/test3/namespaceregistration.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test-namespace-3
+  namespace: {{ .Namespace }}

--- a/pkg/controllers/namespaceregistration/testdata/reconcile/test4/namespaceregistration.yaml
+++ b/pkg/controllers/namespaceregistration/testdata/reconcile/test4/namespaceregistration.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test-namespace-4
+  namespace: {{ .Namespace }}

--- a/pkg/controllers/namespaceregistration/testdata/reconcile/test5/namespaceregistration.yaml
+++ b/pkg/controllers/namespaceregistration/testdata/reconcile/test5/namespaceregistration.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test-namespace-5
+  namespace: {{ .Namespace }}

--- a/pkg/controllers/namespaceregistration/testdata/reconcile/test6/namespaceregistration.yaml
+++ b/pkg/controllers/namespaceregistration/testdata/reconcile/test6/namespaceregistration.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test-namespace-6
+  namespace: {{ .Namespace }}

--- a/pkg/controllers/namespaceregistration/testdata/reconcile/test7/namespaceregistration.yaml
+++ b/pkg/controllers/namespaceregistration/testdata/reconcile/test7/namespaceregistration.yaml
@@ -1,0 +1,5 @@
+apiVersion: landscaper-service.gardener.cloud/v1alpha1
+kind: NamespaceRegistration
+metadata:
+  name: cu-test-namespace-7
+  namespace: {{ .Namespace }}

--- a/pkg/controllers/subjectsync/add.go
+++ b/pkg/controllers/subjectsync/add.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -25,11 +24,8 @@ func AddControllerToManager(logger logging.Logger, mgr manager.Manager, config *
 		return err
 	}
 
-	predicates := builder.WithPredicates(predicate.Or(predicate.LabelChangedPredicate{},
-		predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
-
 	return builder.ControllerManagedBy(mgr).
-		For(&v1alpha1.SubjectList{}, predicates).
+		For(&v1alpha1.SubjectList{}).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
 		Complete(ctrl)
 }

--- a/pkg/controllers/subjectsync/add.go
+++ b/pkg/controllers/subjectsync/add.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -16,7 +17,7 @@ import (
 	"github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 )
 
-// AddControllerToManager adds the Namespaceregistration Controller to the manager
+// AddControllerToManager adds the SubjectList Controller to the manager
 func AddControllerToManager(logger logging.Logger, mgr manager.Manager, config *coreconfig.TargetShootSidecarConfiguration) error {
 	log := logger.Reconciles("SubjectSyncController", "SubjectList")
 	ctrl, err := NewController(log, mgr.GetClient(), mgr.GetScheme(), config)
@@ -24,8 +25,11 @@ func AddControllerToManager(logger logging.Logger, mgr manager.Manager, config *
 		return err
 	}
 
+	predicates := builder.WithPredicates(predicate.Or(predicate.LabelChangedPredicate{},
+		predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{}))
+
 	return builder.ControllerManagedBy(mgr).
-		For(&v1alpha1.SubjectList{}).
+		For(&v1alpha1.SubjectList{}, predicates).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger { return log.Logr() }).
 		Complete(ctrl)
 }

--- a/pkg/controllers/subjectsync/controller.go
+++ b/pkg/controllers/subjectsync/controller.go
@@ -54,6 +54,8 @@ func NewTestActuator(op operation.TargetShootSidecarOperation, logger logging.Lo
 func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	logger, ctx := c.log.StartReconcileAndAddToContext(ctx, req)
 
+	logger.Info("start reconcile subjectList")
+
 	subjectList := &lssv1alpha1.SubjectList{}
 	if err := c.Client().Get(ctx, req.NamespacedName, subjectList); err != nil {
 		logger.Error(err, "failed loading subjectlist cr")

--- a/pkg/controllers/subjectsync/controller.go
+++ b/pkg/controllers/subjectsync/controller.go
@@ -71,7 +71,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		if err := c.Client().Update(ctx, subjectList); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	if !subjectList.DeletionTimestamp.IsZero() {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -83,4 +85,22 @@ func RemoveOperationAnnotation(object client.Object) {
 	if annotations != nil {
 		delete(annotations, lssv1alpha1.LandscaperServiceOperationAnnotation)
 	}
+}
+
+// HasLabel checks if the objects has a label
+func HasLabel(obj metav1.Object, lab string) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, ok := labels[lab]
+	return ok
+}
+
+// HasDeleteWithoutUninstallAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/delete-without-uninstall' annotation
+// and its value is 'true'.
+func HasDeleteWithoutUninstallAnnotation(obj metav1.Object) bool {
+	v, ok := obj.GetAnnotations()[lsv1alpha1.DeleteWithoutUninstallAnnotation]
+	return ok && v == "true"
 }

--- a/test/utils/controller.go
+++ b/test/utils/controller.go
@@ -36,9 +36,10 @@ func RequestFromObject(obj client.Object) reconcile.Request {
 
 // ShouldReconcile reconciles the given reconciler with the given request
 // and expects that no error occurred
-func ShouldReconcile(ctx context.Context, reconciler reconcile.Reconciler, req reconcile.Request, optionalDescription ...interface{}) {
-	_, err := reconciler.Reconcile(ctx, req)
+func ShouldReconcile(ctx context.Context, reconciler reconcile.Reconciler, req reconcile.Request, optionalDescription ...interface{}) reconcile.Result {
+	res, err := reconciler.Reconcile(ctx, req)
 	gomega.ExpectWithOffset(1, err).ToNot(gomega.HaveOccurred(), optionalDescription...)
+	return res
 }
 
 // ShouldNotReconcile reconciles the given reconciler with the given request

--- a/test/utils/envtest/environment.go
+++ b/test/utils/envtest/environment.go
@@ -393,19 +393,37 @@ func (e *Environment) decodeAndAppendLSSObject(data []byte, objects []client.Obj
 	case ConfigMapGVK.Kind:
 		configMap := &corev1.ConfigMap{}
 		if _, _, err := decoder.Decode(data, nil, configMap); err != nil {
-			return nil, fmt.Errorf("unable to decode file as secret: %w", err)
+			return nil, fmt.Errorf("unable to decode file as config map: %w", err)
 		}
 		return append(objects, configMap), nil
 	case InstallationGVK.Kind:
 		installation := &lsv1alpha1.Installation{}
 		if _, _, err := decoder.Decode(data, nil, installation); err != nil {
-			return nil, fmt.Errorf("unable to decode file as secret: %w", err)
+			return nil, fmt.Errorf("unable to decode file as installation: %w", err)
 		}
 		return append(objects, installation), nil
+	case ExecutionGVK.Kind:
+		execution := &lsv1alpha1.Execution{}
+		if _, _, err := decoder.Decode(data, nil, execution); err != nil {
+			return nil, fmt.Errorf("unable to decode file as execution: %w", err)
+		}
+		return append(objects, execution), nil
+	case DeployItemGVK.Kind:
+		di := &lsv1alpha1.DeployItem{}
+		if _, _, err := decoder.Decode(data, nil, di); err != nil {
+			return nil, fmt.Errorf("unable to decode file as deploy item: %w", err)
+		}
+		return append(objects, di), nil
+	case TargetSyncGVK.Kind:
+		di := &lsv1alpha1.TargetSync{}
+		if _, _, err := decoder.Decode(data, nil, di); err != nil {
+			return nil, fmt.Errorf("unable to decode file as targetsync: %w", err)
+		}
+		return append(objects, di), nil
 	case TargetGVK.Kind:
 		target := &lsv1alpha1.Target{}
 		if _, _, err := decoder.Decode(data, nil, target); err != nil {
-			return nil, fmt.Errorf("unable to decode file as secret: %w", err)
+			return nil, fmt.Errorf("unable to decode file as target: %w", err)
 		}
 		return append(objects, target), nil
 	case ContextGVK.Kind:

--- a/test/utils/envtest/state.go
+++ b/test/utils/envtest/state.go
@@ -32,6 +32,12 @@ type State struct {
 	ConfigMaps map[string]*corev1.ConfigMap
 	// Installations contains all installations in this test environment.
 	Installations map[string]*lsv1alpha1.Installation
+	// Executions contains all executions in this test environment.
+	Executions map[string]*lsv1alpha1.Execution
+	// DeployItems contains all DeployItems in this test environment.
+	DeployItems map[string]*lsv1alpha1.DeployItem
+	// TargetSync contains all targetsyncs in this test environment.
+	TargetSync map[string]*lsv1alpha1.TargetSync
 	// Targets contains all targets in this test environment.
 	Targets map[string]*lsv1alpha1.Target
 	// Contexts contains all contexts in this test environment
@@ -56,6 +62,9 @@ func NewState(namespace string) *State {
 		Secrets:                 make(map[string]*corev1.Secret),
 		ConfigMaps:              make(map[string]*corev1.ConfigMap),
 		Installations:           make(map[string]*lsv1alpha1.Installation),
+		Executions:              make(map[string]*lsv1alpha1.Execution),
+		DeployItems:             make(map[string]*lsv1alpha1.DeployItem),
+		TargetSync:              make(map[string]*lsv1alpha1.TargetSync),
 		Targets:                 make(map[string]*lsv1alpha1.Target),
 		Contexts:                make(map[string]*lsv1alpha1.Context),
 		AvailabilityCollections: make(map[string]*lssv1alpha1.AvailabilityCollection),
@@ -93,6 +102,18 @@ func (s *State) GetConfigMap(name string) *corev1.ConfigMap {
 // GetInstallation retrieves an installation by the given name.
 func (s *State) GetInstallation(name string) *lsv1alpha1.Installation {
 	return s.Installations[s.Namespace+"/"+name]
+}
+
+func (s *State) GetExecution(name string) *lsv1alpha1.Execution {
+	return s.Executions[s.Namespace+"/"+name]
+}
+
+func (s *State) GetDeployItem(name string) *lsv1alpha1.DeployItem {
+	return s.DeployItems[s.Namespace+"/"+name]
+}
+
+func (s *State) GetTargetSync(name string) *lsv1alpha1.TargetSync {
+	return s.TargetSync[s.Namespace+"/"+name]
 }
 
 // GetTarget retrieves a target by the given name.
@@ -151,6 +172,12 @@ func (s *State) AddObject(object client.Object) {
 		s.ConfigMaps[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
 	case *lsv1alpha1.Installation:
 		s.Installations[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
+	case *lsv1alpha1.Execution:
+		s.Executions[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
+	case *lsv1alpha1.DeployItem:
+		s.DeployItems[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
+	case *lsv1alpha1.TargetSync:
+		s.TargetSync[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
 	case *lsv1alpha1.Target:
 		s.Targets[types.NamespacedName{Name: o.Name, Namespace: o.Namespace}.String()] = o.DeepCopy()
 	case *lsv1alpha1.Context:

--- a/test/utils/envtest/types.go
+++ b/test/utils/envtest/types.go
@@ -34,6 +34,12 @@ var (
 	ConfigMapGVK schema.GroupVersionKind
 	// InstallationGVK is the GVK for installations.
 	InstallationGVK schema.GroupVersionKind
+	// ExecutionGVK is the GVK for executions.
+	ExecutionGVK schema.GroupVersionKind
+	// DeployItemGVK is the GVK for deploy items.
+	DeployItemGVK schema.GroupVersionKind
+	// TargetSyncGVK is the GVK for target syncs.
+	TargetSyncGVK schema.GroupVersionKind
 	// TargetGVK is the GVK for targets.
 	TargetGVK schema.GroupVersionKind
 	// ContextGVK is the GVK for contexts.
@@ -66,6 +72,12 @@ func init() {
 	ConfigMapGVK, err = apiutil.GVKForObject(&corev1.ConfigMap{}, LandscaperServiceScheme)
 	utilruntime.Must(err)
 	InstallationGVK, err = apiutil.GVKForObject(&lsv1alpha1.Installation{}, LandscaperServiceScheme)
+	utilruntime.Must(err)
+	ExecutionGVK, err = apiutil.GVKForObject(&lsv1alpha1.Execution{}, LandscaperServiceScheme)
+	utilruntime.Must(err)
+	DeployItemGVK, err = apiutil.GVKForObject(&lsv1alpha1.DeployItem{}, LandscaperServiceScheme)
+	utilruntime.Must(err)
+	TargetSyncGVK, err = apiutil.GVKForObject(&lsv1alpha1.TargetSync{}, LandscaperServiceScheme)
 	utilruntime.Must(err)
 	TargetGVK, err = apiutil.GVKForObject(&lsv1alpha1.Target{}, LandscaperServiceScheme)
 	utilruntime.Must(err)

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/dataobjects.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/dataobjects.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"crypto/sha1"
+	"encoding/base32"
+	"fmt"
+	"regexp"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+)
+
+const Base32EncodeStdLowerCase = "abcdefghijklmnopqrstuvwxyz234567"
+
+const SourceDelimiter = "/"
+
+const NonContextifiedPrefix = "#"
+
+// InstallationPrefix is the prefix combined with installation name is used as label value. Do not change length.
+const InstallationPrefix = "Inst."
+
+// ExecutionPrefix is the prefix combined with execution name is used as label value. Do not change length.
+const ExecutionPrefix = "Exec."
+
+var subdomainRegex = regexp.MustCompile("^([a-z0-9]|([a-z0-9][a-z0-9.-]*[a-z0-9]))$")
+
+// GenerateDataObjectName generates the unique name for a data object exported or imported by a installation.
+// It returns a non contextified data name if the name starts with a "#".
+func GenerateDataObjectName(context string, name string) string {
+	if strings.HasPrefix(name, NonContextifiedPrefix) {
+		return strings.TrimPrefix(name, NonContextifiedPrefix)
+	}
+	// for backward compatibility, we need to hash names which are incompatible with the k8s resource naming scheme
+	if len(context) == 0 && subdomainRegex.MatchString(name) {
+		return name
+	}
+	doName := fmt.Sprintf("%s/%s", context, name)
+	h := sha1.New()
+	_, _ = h.Write([]byte(doName))
+	// we need base32 encoding as some base64 (even url safe base64) characters are not supported by k8s
+	// see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
+	return base32.NewEncoding(Base32EncodeStdLowerCase).WithPadding(base32.NoPadding).EncodeToString(h.Sum(nil))
+}
+
+// GenerateDataObjectNameWithIndex generates a unique name for a data object which is part of a list
+// and therefore has no own name but is identified by a combination of name and index.
+// It builds a fake name by combining name and index and then calls GenerateDataObjectName.
+func GenerateDataObjectNameWithIndex(context string, name string, index int) string {
+	return GenerateDataObjectName(context, fmt.Sprintf("%s[%d]", name, index))
+}
+
+// DataObjectSourceFromObject returns the data object source for a runtime object.
+func DataObjectSourceFromObject(src runtime.Object) (string, error) {
+	acc, ok := src.(metav1.Object)
+	if !ok {
+		return "", fmt.Errorf("source has to be a kubernetes metadata object")
+	}
+
+	srcKind := src.GetObjectKind().GroupVersionKind().Kind
+	return srcKind + SourceDelimiter + acc.GetNamespace() + SourceDelimiter + acc.GetName(), nil
+}
+
+// ObjectFromDataObjectSource parses the source's kind, namespace and name from a src string.
+func ObjectFromDataObjectSource(src string) (string, lsv1alpha1.ObjectReference, error) {
+	splitValues := strings.Split(src, SourceDelimiter)
+	if len(splitValues) != 3 {
+		return "", lsv1alpha1.ObjectReference{}, fmt.Errorf("expected source definition with 3 paramters but got %d", len(splitValues))
+	}
+
+	kind, namespace, name := splitValues[0], splitValues[1], splitValues[2]
+	return kind, lsv1alpha1.ObjectReference{Namespace: namespace, Name: name}, nil
+}
+
+// DataObjectSourceFromInstallation returns the data object source for a Installation.
+func DataObjectSourceFromInstallation(src *lsv1alpha1.Installation) string {
+	return InstallationPrefix + src.GetName()
+}
+
+// DataObjectSourceFromInstallationName returns the data object source for an Installation name.
+func DataObjectSourceFromInstallationName(name string) string {
+	return InstallationPrefix + name
+}
+
+// DataObjectSourceFromExecution returns the data object source for a Execution.
+func DataObjectSourceFromExecution(src *lsv1alpha1.Execution) string {
+	return ExecutionPrefix + src.GetName()
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/helpers.go
@@ -1,0 +1,254 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import (
+	"reflect"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
+)
+
+type TimestampAnnotation string
+
+const (
+	ReconcileTimestamp = TimestampAnnotation(v1alpha1.ReconcileTimestampAnnotation)
+)
+
+// HasOperation checks if the obj has the given operation annotation
+func HasOperation(obj metav1.ObjectMeta, op v1alpha1.Operation) bool {
+	currentOp, ok := obj.Annotations[v1alpha1.OperationAnnotation]
+	if !ok {
+		return false
+	}
+
+	return v1alpha1.Operation(currentOp) == op
+}
+
+func GetOperation(obj metav1.ObjectMeta) string {
+	if obj.Annotations == nil {
+		return ""
+	}
+	return obj.Annotations[v1alpha1.OperationAnnotation]
+}
+
+// SetOperation sets the given operation annotation on aa object.
+func SetOperation(obj *metav1.ObjectMeta, op v1alpha1.Operation) {
+	metav1.SetMetaDataAnnotation(obj, v1alpha1.OperationAnnotation, string(op))
+}
+
+func GetTimestampAnnotation(obj metav1.ObjectMeta, ta TimestampAnnotation) (time.Time, error) {
+	return time.Parse(time.RFC3339, obj.Annotations[string(ta)])
+}
+
+// SetTimestampAnnotationNow sets the timeout annotation with the current timestamp.
+func SetTimestampAnnotationNow(obj *metav1.ObjectMeta, ta TimestampAnnotation) {
+	metav1.SetMetaDataAnnotation(obj, string(ta), time.Now().Format(time.RFC3339))
+}
+
+func Touch(obj *metav1.ObjectMeta) {
+	_, ok := obj.Annotations[v1alpha1.TouchAnnotation]
+	if ok {
+		delete(obj.Annotations, v1alpha1.TouchAnnotation)
+	} else {
+		metav1.SetMetaDataAnnotation(obj, v1alpha1.TouchAnnotation, "true")
+	}
+}
+
+// InitCondition initializes a new Condition with an Unknown status.
+func InitCondition(conditionType v1alpha1.ConditionType) v1alpha1.Condition {
+	return v1alpha1.Condition{
+		Type:               conditionType,
+		Status:             v1alpha1.ConditionUnknown,
+		Reason:             "ConditionInitialized",
+		Message:            "The condition has been initialized but its semantic check has not been performed yet.",
+		LastTransitionTime: metav1.Now(),
+	}
+}
+
+// GetCondition returns the condition with the given <conditionType> out of the list of <conditions>.
+// In case the required type could not be found, it returns nil.
+func GetCondition(conditions []v1alpha1.Condition, conditionType v1alpha1.ConditionType) *v1alpha1.Condition {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			c := condition
+			return &c
+		}
+	}
+	return nil
+}
+
+// GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
+// If the condition could not be found, it returns an initialized condition of the given type.
+func GetOrInitCondition(conditions []v1alpha1.Condition, conditionType v1alpha1.ConditionType) v1alpha1.Condition {
+	if condition := GetCondition(conditions, conditionType); condition != nil {
+		return *condition
+	}
+	return InitCondition(conditionType)
+}
+
+// UpdatedCondition updates the properties of one specific condition.
+func UpdatedCondition(condition v1alpha1.Condition, status v1alpha1.ConditionStatus, reason, message string, codes ...v1alpha1.ErrorCode) v1alpha1.Condition {
+	newCondition := v1alpha1.Condition{
+		Type:               condition.Type,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: condition.LastTransitionTime,
+		LastUpdateTime:     condition.LastUpdateTime,
+		Codes:              codes,
+	}
+
+	if !reflect.DeepEqual(condition, newCondition) {
+		newCondition.LastUpdateTime = metav1.Now()
+	}
+
+	if condition.Status != status {
+		newCondition.LastTransitionTime = metav1.Now()
+	}
+
+	return newCondition
+}
+
+// CreateOrUpdateConditions creates or updates a condition in a condition list.
+func CreateOrUpdateConditions(conditions []v1alpha1.Condition, condType v1alpha1.ConditionType, status v1alpha1.ConditionStatus, reason, message string, codes ...v1alpha1.ErrorCode) []v1alpha1.Condition {
+	for i, foundCondition := range conditions {
+		if foundCondition.Type == condType {
+			conditions[i] = UpdatedCondition(conditions[i], status, reason, message, codes...)
+			return conditions
+		}
+	}
+
+	return append(conditions, UpdatedCondition(InitCondition(condType), status, reason, message, codes...))
+}
+
+// MergeConditions merges the given <oldConditions> with the <newConditions>. Existing conditions are superseded by
+// the <newConditions> (depending on the condition type).
+func MergeConditions(oldConditions []v1alpha1.Condition, newConditions ...v1alpha1.Condition) []v1alpha1.Condition {
+	var (
+		out         = make([]v1alpha1.Condition, 0, len(oldConditions))
+		typeToIndex = make(map[v1alpha1.ConditionType]int, len(oldConditions))
+	)
+
+	for i, condition := range oldConditions {
+		out = append(out, condition)
+		typeToIndex[condition.Type] = i
+	}
+
+	for _, condition := range newConditions {
+		if index, ok := typeToIndex[condition.Type]; ok {
+			out[index] = condition
+			continue
+		}
+		out = append(out, condition)
+	}
+
+	return out
+}
+
+// IsConditionStatus returns if all condition states of all conditions are true.
+func IsConditionStatus(conditions []v1alpha1.Condition, status v1alpha1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Status != status {
+			return false
+		}
+	}
+	return true
+}
+
+// ObjectReferenceFromObject creates a object reference from a k8s object
+func ObjectReferenceFromObject(obj metav1.Object) v1alpha1.ObjectReference {
+	return v1alpha1.ObjectReference{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	}
+}
+
+// CreateOrUpdateVersionedObjectReferences creates or updates a element in versioned objectReference slice.
+func CreateOrUpdateVersionedObjectReferences(refs []v1alpha1.VersionedObjectReference, ref v1alpha1.ObjectReference, gen int64) []v1alpha1.VersionedObjectReference {
+	for i, vref := range refs {
+		if vref.ObjectReference == ref {
+			refs[i] = v1alpha1.VersionedObjectReference{
+				ObjectReference:    ref,
+				ObservedGeneration: gen,
+			}
+			return refs
+		}
+	}
+	return append(refs, v1alpha1.VersionedObjectReference{
+		ObjectReference:    ref,
+		ObservedGeneration: gen,
+	})
+}
+
+// GetNamedObjectReference returns the object reference with the given name.
+func GetNamedObjectReference(objects []v1alpha1.NamedObjectReference, name string) (v1alpha1.NamedObjectReference, bool) {
+	for _, ref := range objects {
+		if ref.Name == name {
+			return ref, true
+		}
+	}
+	return v1alpha1.NamedObjectReference{}, false
+}
+
+// ReferenceIsObject checks if the reference describes the given object.
+func ReferenceIsObject(ref v1alpha1.ObjectReference, obj metav1.Object) bool {
+	return ref.Name == obj.GetName() && ref.Namespace == obj.GetNamespace()
+}
+
+// SetVersionedNamedObjectReference sets the versioned object reference with the given name.
+func SetVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectReference, obj v1alpha1.VersionedNamedObjectReference) []v1alpha1.VersionedNamedObjectReference {
+	for i, ref := range objects {
+		if ref.Name == obj.Name {
+			objects[i] = obj
+			return objects
+		}
+	}
+	return append(objects, obj)
+}
+
+// RemoveVersionedNamedObjectReference removes the first versioned object reference with the given name.
+func RemoveVersionedNamedObjectReference(objects []v1alpha1.VersionedNamedObjectReference, name string) []v1alpha1.VersionedNamedObjectReference {
+	for i, ref := range objects {
+		if ref.Name == name {
+			return append(objects[:i], objects[i+1:]...)
+		}
+	}
+	return objects
+}
+
+// HasIgnoreAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/ignore' annotation
+// and its value is 'true'.
+func HasIgnoreAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.IgnoreAnnotation]
+	return ok && v == "true"
+}
+
+// HasDeleteWithoutUninstallAnnotation returns true only if the given object
+// has the 'landscaper.gardener.cloud/delete-without-uninstall' annotation
+// and its value is 'true'.
+func HasDeleteWithoutUninstallAnnotation(obj metav1.ObjectMeta) bool {
+	v, ok := obj.GetAnnotations()[v1alpha1.DeleteWithoutUninstallAnnotation]
+	return ok && v == "true"
+}
+
+// SetDeployItemToFailed sets status.phase of the DeployItem to a failure phase
+// If the DeployItem has a DeletionTimestamp, 'DeleteFailed' is used, otherwise it will be set to 'Failed'.
+// Afterwards, the set phase is returned.
+// Will do nothing and return an empty string if given a nil pointer.
+func SetDeployItemToFailed(di *v1alpha1.DeployItem) v1alpha1.DeployItemPhase {
+	if di == nil {
+		return ""
+	}
+	if !di.ObjectMeta.DeletionTimestamp.IsZero() {
+		di.Status.Phase = v1alpha1.DeployItemPhases.DeleteFailed
+	} else {
+		di.Status.Phase = v1alpha1.DeployItemPhases.Failed
+	}
+	return di.Status.Phase
+}

--- a/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/installationstate.go
+++ b/vendor/github.com/gardener/landscaper/apis/core/v1alpha1/helper/installationstate.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2020 SAP SE or an SAP affiliate company and Gardener contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helper
+
+import landscaperv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
+
+// NewInstallationReferenceState creates a new installation reference state from a given installation
+func NewInstallationReferenceState(name string, inst *landscaperv1alpha1.Installation) landscaperv1alpha1.NamedObjectReference {
+	return landscaperv1alpha1.NamedObjectReference{
+		Name: name,
+		Reference: landscaperv1alpha1.ObjectReference{
+			Name:      inst.Name,
+			Namespace: inst.Namespace,
+		},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -42,6 +42,7 @@ github.com/gardener/landscaper/apis/config
 github.com/gardener/landscaper/apis/core
 github.com/gardener/landscaper/apis/core/install
 github.com/gardener/landscaper/apis/core/v1alpha1
+github.com/gardener/landscaper/apis/core/v1alpha1/helper
 github.com/gardener/landscaper/apis/core/v1alpha1/targettypes
 github.com/gardener/landscaper/apis/hack/generate-schemes/app
 github.com/gardener/landscaper/apis/hack/generate-schemes/generators


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not start deleting the namespace as long as there are still Installations, Executions and DeployItems, which all have finalizers and must be removed first.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- Namespace only deleted if all Installations, Executions and DeployItems removed
```
