### PR TITLE
add log message for mismatched lshealthcheck counts

### DIFF
--- a/pkg/controllers/avmonitorregistration/controller.go
+++ b/pkg/controllers/avmonitorregistration/controller.go
@@ -86,6 +86,7 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			continue
 		}
 
+		logger.Info("add instance to be monitored")
 		instanceRefsToMonitor = append(instanceRefsToMonitor, lssv1alpha1.ObjectReference{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,

--- a/pkg/controllers/healthwatcher/controllger.go
+++ b/pkg/controllers/healthwatcher/controllger.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	lsv1alpha1 "github.com/gardener/landscaper/apis/core/v1alpha1"
@@ -212,6 +213,21 @@ func (c *Controller) getLsHealthCheckFromSelfLandscaper(ctx context.Context, nam
 		}
 		c.log.Info(fmt.Sprintf("could not load lshealthcheck from cluster: %s", err.Error()))
 		setAvailabilityInstanceStatusToFailed(&availabilityInstance, "failed retrieving lshealthcheck cr")
+	}
+	if len(lsHealthchecks.Items) != 1 {
+		if len(lsHealthchecks.Items) > 0 {
+			lsHealthCheckNames := strings.Builder{}
+			for _, item := range lsHealthchecks.Items {
+				if lsHealthCheckNames.Len() > 0 {
+					lsHealthCheckNames.WriteString(",")
+				}
+				lsHealthCheckNames.WriteString(item.Name)
+
+			}
+			c.log.Info("number of lshealthcheck instances is not equal to 1", "lshHealthCheckInstanceCount", len(lsHealthchecks.Items), "lsHealthCheckNames", lsHealthCheckNames.String())
+		} else {
+			c.log.Info("number of lshealthcheck instances is not equal to 1", "lshHealthCheckInstanceCount", len(lsHealthchecks.Items))
+		}
 	}
 	transferLsHealthCheckStatusToAvailabilityInstance(&availabilityInstance, lsHealthchecks, c.Config().AvailabilityMonitoring.LSHealthCheckTimeout.Duration)
 	return availabilityInstance


### PR DESCRIPTION
**What this PR does / why we need it**:

Add more detailed log message when the number of lshealthchecks is not in the expected range.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add more detailed log message when the number of lshealthchecks is not in the expected range.
```
