### PR TITLE
Make OCM lib configurable per instance

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/landscaper/deploy-execution.yaml
@@ -65,6 +65,10 @@ deployItems:
 
           deployersConfig: {}
 
+          {{- if (dig "landscaperConfig" "landscaper" "useOCMLib" false .imports) }}
+          useOCMLib: true
+          {{- end }}
+
           {{- if (dig "landscaperConfig" "landscaper" "deployItemTimeouts" false .imports) }}
           deployItemTimeouts:
           {{- toYaml .imports.landscaperConfig.landscaper.deployItemTimeouts | nindent 12 }}
@@ -256,6 +260,10 @@ deployItems:
           averageMemoryUtilization: {{ .imports.landscaperConfig.deployersConfig.helm.hpa.averageMemoryUtilization }}
           {{- end }}
         {{- end }}
+
+        {{- if (dig "landscaperConfig" "landscaper" "useOCMLib" false .imports) }}
+        useOCMLib: true
+        {{- end }}
 {{ end }}
 
 {{ if has "manifest" .imports.landscaperConfig.deployers }}
@@ -329,6 +337,10 @@ deployItems:
           averageMemoryUtilization: {{ .imports.landscaperConfig.deployersConfig.manifest.hpa.averageMemoryUtilization }}
           {{- end }}
         {{- end }}
+
+        {{- if (dig "landscaperConfig" "landscaper" "useOCMLib" false .imports) }}
+        useOCMLib: true
+        {{- end }}
 {{ end }}
 
 {{ if has "container" .imports.landscaperConfig.deployers }}
@@ -401,5 +413,9 @@ deployItems:
           {{- if (dig "landscaperConfig" "deployersConfig" "container" "hpa" "averageMemoryUtilization" false .imports) }}
           averageMemoryUtilization: {{ .imports.landscaperConfig.deployersConfig.container.hpa.averageMemoryUtilization }}
           {{- end }}
+        {{- end }}
+
+        {{- if (dig "landscaperConfig" "landscaper" "useOCMLib" false .imports) }}
+        useOCMLib: true
         {{- end }}
 {{ end }}

--- a/.landscaper/landscaper-instance/definition/landscaper-configuration.json
+++ b/.landscaper/landscaper-instance/definition/landscaper-configuration.json
@@ -47,6 +47,9 @@
         "k8sClientSettings": {
           "type": "object"
         },
+        "useOCMLib": {
+          "type": "boolean"
+        },
         "deployItemTimeouts": {
           "type": "object"
         }

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/types_shared.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/types_shared.go
@@ -94,6 +94,7 @@ type Landscaper struct {
 	Controllers        *Controllers        `json:"controllers,omitempty"`
 	K8SClientSettings  *K8SClientSettings  `json:"k8sClientSettings,omitempty"`
 	DeployItemTimeouts *DeployItemTimeouts `json:"deployItemTimeouts,omitempty"`
+	UseOCMLib          bool                `json:"useOCMLib,omitempty"`
 }
 
 // Controllers specifies the config for the "main" landscaper controllers, i.e. the installation and execution controller.

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_shared.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_shared.go
@@ -94,6 +94,7 @@ type Landscaper struct {
 	Controllers        *Controllers        `json:"controllers,omitempty"`
 	K8SClientSettings  *K8SClientSettings  `json:"k8sClientSettings,omitempty"`
 	DeployItemTimeouts *DeployItemTimeouts `json:"deployItemTimeouts,omitempty"`
+	UseOCMLib          bool                `json:"useOCMLib,omitempty"`
 }
 
 // Controllers specifies the config for the "main" landscaper controllers, i.e. the installation and execution controller.

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1002,6 +1002,7 @@ func autoConvert_v1alpha1_Landscaper_To_core_Landscaper(in *Landscaper, out *cor
 	out.Controllers = (*core.Controllers)(unsafe.Pointer(in.Controllers))
 	out.K8SClientSettings = (*core.K8SClientSettings)(unsafe.Pointer(in.K8SClientSettings))
 	out.DeployItemTimeouts = (*core.DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -1014,6 +1015,7 @@ func autoConvert_core_Landscaper_To_v1alpha1_Landscaper(in *core.Landscaper, out
 	out.Controllers = (*Controllers)(unsafe.Pointer(in.Controllers))
 	out.K8SClientSettings = (*K8SClientSettings)(unsafe.Pointer(in.K8SClientSettings))
 	out.DeployItemTimeouts = (*DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/pkg/apis/.schemes/core-v1alpha1-Instance.json
+++ b/pkg/apis/.schemes/core-v1alpha1-Instance.json
@@ -286,6 +286,9 @@
         },
         "k8sClientSettings": {
           "$ref": "#/definitions/core-v1alpha1-K8SClientSettings"
+        },
+        "useOCMLib": {
+          "type": "boolean"
         }
       }
     },

--- a/pkg/apis/.schemes/core-v1alpha1-LandscaperDeployment.json
+++ b/pkg/apis/.schemes/core-v1alpha1-LandscaperDeployment.json
@@ -168,6 +168,9 @@
         },
         "k8sClientSettings": {
           "$ref": "#/definitions/core-v1alpha1-K8SClientSettings"
+        },
+        "useOCMLib": {
+          "type": "boolean"
         }
       }
     },

--- a/pkg/apis/core/types_shared.go
+++ b/pkg/apis/core/types_shared.go
@@ -94,6 +94,7 @@ type Landscaper struct {
 	Controllers        *Controllers        `json:"controllers,omitempty"`
 	K8SClientSettings  *K8SClientSettings  `json:"k8sClientSettings,omitempty"`
 	DeployItemTimeouts *DeployItemTimeouts `json:"deployItemTimeouts,omitempty"`
+	UseOCMLib          bool                `json:"useOCMLib,omitempty"`
 }
 
 // Controllers specifies the config for the "main" landscaper controllers, i.e. the installation and execution controller.

--- a/pkg/apis/core/v1alpha1/types_shared.go
+++ b/pkg/apis/core/v1alpha1/types_shared.go
@@ -94,6 +94,7 @@ type Landscaper struct {
 	Controllers        *Controllers        `json:"controllers,omitempty"`
 	K8SClientSettings  *K8SClientSettings  `json:"k8sClientSettings,omitempty"`
 	DeployItemTimeouts *DeployItemTimeouts `json:"deployItemTimeouts,omitempty"`
+	UseOCMLib          bool                `json:"useOCMLib,omitempty"`
 }
 
 // Controllers specifies the config for the "main" landscaper controllers, i.e. the installation and execution controller.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -1002,6 +1002,7 @@ func autoConvert_v1alpha1_Landscaper_To_core_Landscaper(in *Landscaper, out *cor
 	out.Controllers = (*core.Controllers)(unsafe.Pointer(in.Controllers))
 	out.K8SClientSettings = (*core.K8SClientSettings)(unsafe.Pointer(in.K8SClientSettings))
 	out.DeployItemTimeouts = (*core.DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 
@@ -1014,6 +1015,7 @@ func autoConvert_core_Landscaper_To_v1alpha1_Landscaper(in *core.Landscaper, out
 	out.Controllers = (*Controllers)(unsafe.Pointer(in.Controllers))
 	out.K8SClientSettings = (*K8SClientSettings)(unsafe.Pointer(in.K8SClientSettings))
 	out.DeployItemTimeouts = (*DeployItemTimeouts)(unsafe.Pointer(in.DeployItemTimeouts))
+	out.UseOCMLib = in.UseOCMLib
 	return nil
 }
 

--- a/pkg/apis/installation/installation.go
+++ b/pkg/apis/installation/installation.go
@@ -117,6 +117,7 @@ type Landscaper struct {
 	DeployItemTimeouts *lssv1alpha1.DeployItemTimeouts `json:"deployItemTimeouts,omitempty"`
 	// K8SClientSettings defines k8s client settings like burst and qps.
 	K8SClientSettings *lssv1alpha1.K8SClientSettings `json:"k8sClientSettings,omitempty"`
+	UseOCMLib         bool                           `json:"useOCMLib,omitempty"`
 }
 
 // Webhooks specifies the landscaper webhooks server configuration.

--- a/pkg/apis/openapi/openapi_generated.go
+++ b/pkg/apis/openapi/openapi_generated.go
@@ -1261,6 +1261,12 @@ func schema_pkg_apis_core_v1alpha1_Landscaper(ref common.ReferenceCallback) comm
 							Ref: ref("github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1.DeployItemTimeouts"),
 						},
 					},
+					"useOCMLib": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/controllers/instances/reconcile.go
+++ b/pkg/controllers/instances/reconcile.go
@@ -430,6 +430,7 @@ func (c *Controller) mutateInstallation(ctx context.Context, installation *lsv1a
 		landscaperConfig.Landscaper.Controllers = instance.Spec.LandscaperConfiguration.Landscaper.Controllers
 		landscaperConfig.Landscaper.DeployItemTimeouts = instance.Spec.LandscaperConfiguration.Landscaper.DeployItemTimeouts
 		landscaperConfig.Landscaper.K8SClientSettings = instance.Spec.LandscaperConfiguration.Landscaper.K8SClientSettings
+		landscaperConfig.Landscaper.UseOCMLib = instance.Spec.LandscaperConfiguration.Landscaper.UseOCMLib
 	}
 
 	landscaperConfigRaw, err := landscaperConfig.ToAnyJSON()

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_instances.yaml
@@ -217,6 +217,8 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      useOCMLib:
+                        type: boolean
                     type: object
                   resources:
                     description: Resources configures the resources of the "central"

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_landscaperdeployments.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_landscaperdeployments.yaml
@@ -199,6 +199,8 @@ spec:
                                 type: integer
                             type: object
                         type: object
+                      useOCMLib:
+                        type: boolean
                     type: object
                   resources:
                     description: Resources configures the resources of the "central"


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request makes the OCM lib configurable per `LandscaperDeployment` (flag `useOCMLib`).

```yaml
kind: LandscaperDeployment
spec:
  landscaperConfiguration:
    landscaper:
      useOCMLib: true
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- the OCM lib is configurable per instance
```
