### PR TITLE
Upgrade to go 1.20.10 (run-int-tests)

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -29,7 +29,7 @@ landscaper-service:
             image: eu.gcr.io/gardener-project/landscaper-service/landscaper-service-target-shoot-sidecar-server
     steps:
       verify:
-        image: 'golang:1.20.6'
+        image: 'golang:1.20.10'
       publish-helm-charts:
         depends:
         - verify
@@ -41,7 +41,7 @@ landscaper-service:
           depends:
             - publish
             - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.10-alpine3.18'
           execute:
             - "integration_test"
           output_dir: 'integration_test'
@@ -62,7 +62,7 @@ landscaper-service:
           depends: 
           - publish
           - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.10-alpine3.18'
           execute:
           - "integration_test_pr"
           output_dir: 'integration_test'
@@ -90,7 +90,7 @@ landscaper-service:
           depends:
             - publish
             - publish-helm-charts
-          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18'
+          image: 'eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.10-alpine3.18'
           execute:
             - "integration_test"
           output_dir: 'integration_test'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #### BUILDER ####
-FROM golang:1.20.6 AS builder
+FROM golang:1.20.10 AS builder
 
 WORKDIR /go/src/github.com/gardener/landscaper-service
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,4 @@ build-resources: docker-all helm-charts cnudie
 
 .PHONY: build-int-test-image
 build-int-test-image:
-	@docker buildx build --platform linux/amd64 integration-test/docker -t eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.6-alpine3.18 --push
+	@docker buildx build --platform linux/amd64 integration-test/docker -t eu.gcr.io/gardener-project/landscaper-service/integration-test:1.20.10-alpine3.18 --push

--- a/integration-test/docker/Dockerfile
+++ b/integration-test/docker/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.20.6-alpine3.18
+FROM golang:1.20.10-alpine3.18
 
 RUN apk add --no-cache --no-progress \
     bash \


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature dependency
Upgrade to go 1.20.10 fixes following CVEs:
 - CVE-2023-39323
 - CVE-2023-29409
 - CVE-2023-39318
 - CVE-2023-39319
```
