### PR TITLE
Fix healthcheck

### DIFF
--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/types_availabilitycollection.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/types_availabilitycollection.go
@@ -63,6 +63,10 @@ type AvailabilityInstance struct {
 	Status string `json:"status"`
 	// FailedReason is the reason the status is in failed.
 	FailedReason string `json:"failedReason"`
+
+	// FailedSince contains the timestamp since the object is in failed status
+	// +optional
+	FailedSince *metav1.Time `json:"failedSince,omitempty"`
 }
 
 // AvailabilityCollectionSpec contains the spec for the AvailabilityCollection.

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_availabilitycollection.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/types_availabilitycollection.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsschema "github.com/gardener/landscaper/apis/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -64,6 +65,24 @@ type AvailabilityInstance struct {
 	Status string `json:"status"`
 	// FailedReason is the reason the status is in failed.
 	FailedReason string `json:"failedReason"`
+
+	// FailedSince contains the timestamp since the object is in failed status
+	// +optional
+	FailedSince *metav1.Time `json:"failedSince,omitempty"`
+}
+
+func (r *AvailabilityInstance) SetStatusAndFailedSince(status v1alpha1.LsHealthCheckStatus, failedReason string, initOrContinueFailed bool) {
+	r.Status = string(status)
+	r.FailedReason = failedReason
+
+	if initOrContinueFailed {
+		if r.FailedSince == nil {
+			now := metav1.Now()
+			r.FailedSince = &now
+		}
+	} else {
+		r.FailedSince = nil
+	}
 }
 
 // AvailabilityCollectionSpec contains the spec for the AvailabilityCollection.

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -13,6 +13,7 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
@@ -611,6 +612,7 @@ func autoConvert_v1alpha1_AvailabilityInstance_To_core_AvailabilityInstance(in *
 	}
 	out.Status = in.Status
 	out.FailedReason = in.FailedReason
+	out.FailedSince = (*v1.Time)(unsafe.Pointer(in.FailedSince))
 	return nil
 }
 
@@ -625,6 +627,7 @@ func autoConvert_core_AvailabilityInstance_To_v1alpha1_AvailabilityInstance(in *
 	}
 	out.Status = in.Status
 	out.FailedReason = in.FailedReason
+	out.FailedSince = (*v1.Time)(unsafe.Pointer(in.FailedSince))
 	return nil
 }
 

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -121,9 +121,11 @@ func (in *AvailabilityCollectionStatus) DeepCopyInto(out *AvailabilityCollection
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
 		*out = make([]AvailabilityInstance, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
-	out.Self = in.Self
+	in.Self.DeepCopyInto(&out.Self)
 	return
 }
 
@@ -141,6 +143,10 @@ func (in *AvailabilityCollectionStatus) DeepCopy() *AvailabilityCollectionStatus
 func (in *AvailabilityInstance) DeepCopyInto(out *AvailabilityInstance) {
 	*out = *in
 	out.ObjectReference = in.ObjectReference
+	if in.FailedSince != nil {
+		in, out := &in.FailedSince, &out.FailedSince
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/zz_generated.deepcopy.go
+++ b/integration-test/vendor/github.com/gardener/landscaper-service/pkg/apis/core/zz_generated.deepcopy.go
@@ -121,9 +121,11 @@ func (in *AvailabilityCollectionStatus) DeepCopyInto(out *AvailabilityCollection
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
 		*out = make([]AvailabilityInstance, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
-	out.Self = in.Self
+	in.Self.DeepCopyInto(&out.Self)
 	return
 }
 
@@ -141,6 +143,10 @@ func (in *AvailabilityCollectionStatus) DeepCopy() *AvailabilityCollectionStatus
 func (in *AvailabilityInstance) DeepCopyInto(out *AvailabilityInstance) {
 	*out = *in
 	out.ObjectReference = in.ObjectReference
+	if in.FailedSince != nil {
+		in, out := &in.FailedSince, &out.FailedSince
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/.schemes/core-v1alpha1-AvailabilityInstance.json
+++ b/pkg/apis/.schemes/core-v1alpha1-AvailabilityInstance.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
-  "definitions": {},
+  "definitions": {
+    "meta-v1-Time": {
+      "description": "Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.  Wrappers are provided for many of the factory methods that the time package offers.",
+      "type": "string",
+      "format": "date-time"
+    }
+  },
   "description": "AvailabilityInstance contains the availability status for one instance.",
   "properties": {
     "failedReason": {
       "default": "",
       "description": "FailedReason is the reason the status is in failed.",
       "type": "string"
+    },
+    "failedSince": {
+      "$ref": "#/definitions/meta-v1-Time",
+      "description": "FailedSince contains the timestamp since the object is in failed status"
     },
     "name": {
       "default": "",

--- a/pkg/apis/core/types_availabilitycollection.go
+++ b/pkg/apis/core/types_availabilitycollection.go
@@ -63,6 +63,10 @@ type AvailabilityInstance struct {
 	Status string `json:"status"`
 	// FailedReason is the reason the status is in failed.
 	FailedReason string `json:"failedReason"`
+
+	// FailedSince contains the timestamp since the object is in failed status
+	// +optional
+	FailedSince *metav1.Time `json:"failedSince,omitempty"`
 }
 
 // AvailabilityCollectionSpec contains the spec for the AvailabilityCollection.

--- a/pkg/apis/core/v1alpha1/types_availabilitycollection.go
+++ b/pkg/apis/core/v1alpha1/types_availabilitycollection.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	"github.com/gardener/landscaper/apis/core/v1alpha1"
 	lsschema "github.com/gardener/landscaper/apis/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -64,6 +65,24 @@ type AvailabilityInstance struct {
 	Status string `json:"status"`
 	// FailedReason is the reason the status is in failed.
 	FailedReason string `json:"failedReason"`
+
+	// FailedSince contains the timestamp since the object is in failed status
+	// +optional
+	FailedSince *metav1.Time `json:"failedSince,omitempty"`
+}
+
+func (r *AvailabilityInstance) SetStatusAndFailedSince(status v1alpha1.LsHealthCheckStatus, failedReason string, initOrContinueFailed bool) {
+	r.Status = string(status)
+	r.FailedReason = failedReason
+
+	if initOrContinueFailed {
+		if r.FailedSince == nil {
+			now := metav1.Now()
+			r.FailedSince = &now
+		}
+	} else {
+		r.FailedSince = nil
+	}
 }
 
 // AvailabilityCollectionSpec contains the spec for the AvailabilityCollection.

--- a/pkg/apis/core/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.conversion.go
@@ -13,6 +13,7 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 
@@ -611,6 +612,7 @@ func autoConvert_v1alpha1_AvailabilityInstance_To_core_AvailabilityInstance(in *
 	}
 	out.Status = in.Status
 	out.FailedReason = in.FailedReason
+	out.FailedSince = (*v1.Time)(unsafe.Pointer(in.FailedSince))
 	return nil
 }
 
@@ -625,6 +627,7 @@ func autoConvert_core_AvailabilityInstance_To_v1alpha1_AvailabilityInstance(in *
 	}
 	out.Status = in.Status
 	out.FailedReason = in.FailedReason
+	out.FailedSince = (*v1.Time)(unsafe.Pointer(in.FailedSince))
 	return nil
 }
 

--- a/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1alpha1/zz_generated.deepcopy.go
@@ -121,9 +121,11 @@ func (in *AvailabilityCollectionStatus) DeepCopyInto(out *AvailabilityCollection
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
 		*out = make([]AvailabilityInstance, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
-	out.Self = in.Self
+	in.Self.DeepCopyInto(&out.Self)
 	return
 }
 
@@ -141,6 +143,10 @@ func (in *AvailabilityCollectionStatus) DeepCopy() *AvailabilityCollectionStatus
 func (in *AvailabilityInstance) DeepCopyInto(out *AvailabilityInstance) {
 	*out = *in
 	out.ObjectReference = in.ObjectReference
+	if in.FailedSince != nil {
+		in, out := &in.FailedSince, &out.FailedSince
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/core/zz_generated.deepcopy.go
+++ b/pkg/apis/core/zz_generated.deepcopy.go
@@ -121,9 +121,11 @@ func (in *AvailabilityCollectionStatus) DeepCopyInto(out *AvailabilityCollection
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
 		*out = make([]AvailabilityInstance, len(*in))
-		copy(*out, *in)
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
-	out.Self = in.Self
+	in.Self.DeepCopyInto(&out.Self)
 	return
 }
 
@@ -141,6 +143,10 @@ func (in *AvailabilityCollectionStatus) DeepCopy() *AvailabilityCollectionStatus
 func (in *AvailabilityInstance) DeepCopyInto(out *AvailabilityInstance) {
 	*out = *in
 	out.ObjectReference = in.ObjectReference
+	if in.FailedSince != nil {
+		in, out := &in.FailedSince, &out.FailedSince
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/openapi/openapi_generated.go
+++ b/pkg/apis/openapi/openapi_generated.go
@@ -688,10 +688,18 @@ func schema_pkg_apis_core_v1alpha1_AvailabilityInstance(ref common.ReferenceCall
 							Format:      "",
 						},
 					},
+					"failedSince": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailedSince contains the timestamp since the object is in failed status",
+							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Time"),
+						},
+					},
 				},
 				Required: []string{"name", "status", "failedReason"},
 			},
 		},
+		Dependencies: []string{
+			"k8s.io/apimachinery/pkg/apis/meta/v1.Time"},
 	}
 }
 
@@ -2963,6 +2971,13 @@ func schema_landscaper_apis_core_v1alpha1_Context(ref common.ReferenceCallback) 
 							Ref:         ref("github.com/gardener/component-spec/bindings-go/apis/v2.UnstructuredTypedObject"),
 						},
 					},
+					"useOCM": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UseOCM defines whether OCM is used to process installations that reference this context.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"registryPullSecrets": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
@@ -3396,20 +3411,6 @@ func schema_landscaper_apis_core_v1alpha1_DeployItemSpec(ref common.ReferenceCal
 						SchemaProps: spec.SchemaProps{
 							Description: "Configuration contains the deployer type specific configuration.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
-						},
-					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
 						},
 					},
 					"timeout": {
@@ -4296,25 +4297,11 @@ func schema_landscaper_apis_core_v1alpha1_ExecutionSpec(ref common.ReferenceCall
 							Format:      "byte",
 						},
 					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
-						},
-					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.DeployItemTemplate", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.DeployItemTemplate"},
 	}
 }
 
@@ -4930,20 +4917,6 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 							Ref:         ref("github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition"),
 						},
 					},
-					"registryPullSecrets": {
-						SchemaProps: spec.SchemaProps{
-							Description: "RegistryPullSecrets defines a list of registry credentials that are used to pull blueprints, component descriptors and jsonschemas from the respective registry. For more info see: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ Note that the type information is used to determine the secret key and the type of the secret.",
-							Type:        []string{"array"},
-							Items: &spec.SchemaOrArray{
-								Schema: &spec.Schema{
-									SchemaProps: spec.SchemaProps{
-										Default: map[string]interface{}{},
-										Ref:     ref("github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"),
-									},
-								},
-							},
-						},
-					},
 					"imports": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Imports define the imported data objects and targets.",
@@ -4997,7 +4970,7 @@ func schema_landscaper_apis_core_v1alpha1_InstallationSpec(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/gardener/landscaper/apis/core/v1alpha1.AnyJSON", "github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcile", "github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.ComponentDescriptorDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationExports", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationImports", "github.com/gardener/landscaper/apis/core/v1alpha1.ObjectReference"},
+			"github.com/gardener/landscaper/apis/core/v1alpha1.AnyJSON", "github.com/gardener/landscaper/apis/core/v1alpha1.AutomaticReconcile", "github.com/gardener/landscaper/apis/core/v1alpha1.BlueprintDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.ComponentDescriptorDefinition", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationExports", "github.com/gardener/landscaper/apis/core/v1alpha1.InstallationImports"},
 	}
 }
 

--- a/pkg/controllers/healthwatcher/export_test.go
+++ b/pkg/controllers/healthwatcher/export_test.go
@@ -1,6 +1,0 @@
-// SPDX-FileCopyrightText: 2022 "SAP SE or an SAP affiliate company and Gardener contributors"
-//
-// SPDX-License-Identifier: Apache-2.0
-package healthwatcher
-
-var ExportTransferLsHealthCheckStatusToAvailabilityInstance = transferLsHealthCheckStatusToAvailabilityInstance

--- a/pkg/controllers/healthwatcher/reconcile_test.go
+++ b/pkg/controllers/healthwatcher/reconcile_test.go
@@ -92,10 +92,31 @@ var _ = Describe("Reconcile", func() {
 
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
 		Expect(availabilityCollection.Status.Self.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
-		Expect(availabilityCollection.Status.Self.FailedReason).To(ContainSubstring("timeout"))
+		Expect(availabilityCollection.Status.Self.FailedReason).To(ContainSubstring("timeout - last update time not recent enough"))
 	})
 
-	It("should add self monitoring status as success with lshealthcheck failed state if it is not in timoueout", func() {
+	It("should add self monitoring status as failed due to timeout and failed status", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test1")
+		Expect(err).ToNot(HaveOccurred())
+		op.Config().AvailabilityMonitoring.AvailabilityCollectionNamespace = state.Namespace
+		op.Config().AvailabilityMonitoring.SelfLandscaperNamespace = state.Namespace
+
+		//set lastUpdateTime of LsHealthCheck to a timed-out value
+		lsHealthObject := state.GetLsHealthCheck("default")
+		lsHealthObject.Status = lsv1alpha1.LsHealthCheckStatusFailed
+		lsHealthObject.LastUpdateTime = v1.Time{Time: v1.Now().Add(time.Minute * -6)}
+		Expect(testenv.Client.Update(ctx, lsHealthObject)).To(Succeed())
+
+		availabilityCollection := state.GetAvailabilityCollection("availability")
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(availabilityCollection))
+
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
+		Expect(availabilityCollection.Status.Self.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(availabilityCollection.Status.Self.FailedReason).To(ContainSubstring("timeout - failed recovering from failed state within time"))
+	})
+
+	It("should add self monitoring status as success with lshealthcheck failed state if it is not in timeout", func() {
 		var err error
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test2")
 		Expect(err).ToNot(HaveOccurred())
@@ -113,7 +134,39 @@ var _ = Describe("Reconcile", func() {
 		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
 		Expect(availabilityCollection.Status.Self.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
 		Expect(availabilityCollection.Status.Self.FailedReason).To(ContainSubstring("to transition to status=Failed"))
+		Expect(availabilityCollection.Status.Self.FailedSince.Before(&lsHealthObject.LastUpdateTime)).To(BeFalse())
 	})
+
+	It("should add self monitoring status as failed with lshealthcheck failed state for long time", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test2")
+		Expect(err).ToNot(HaveOccurred())
+		op.Config().AvailabilityMonitoring.AvailabilityCollectionNamespace = state.Namespace
+		op.Config().AvailabilityMonitoring.SelfLandscaperNamespace = state.Namespace
+
+		//set lastUpdateTime of LsHealthCheck to recent
+		lsHealthObject := state.GetLsHealthCheck("default")
+		lsHealthObject.Status = lsv1alpha1.LsHealthCheckStatusFailed
+		lsHealthObject.LastUpdateTime = v1.Now()
+		Expect(testenv.Client.Update(ctx, lsHealthObject)).To(Succeed())
+
+		availabilityCollection := state.GetAvailabilityCollection("availability")
+		now := v1.Now()
+		since := v1.Time{Time: now.Add(time.Second * -360)}
+		sinceBefore := v1.Time{Time: now.Add(time.Second * -361)}
+		sinceAfter := v1.Time{Time: now.Add(time.Second * -359)}
+		availabilityCollection.Status.Self.FailedSince = &since
+		Expect(testenv.Client.Status().Update(ctx, availabilityCollection)).To(Succeed())
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(availabilityCollection))
+
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
+		Expect(availabilityCollection.Status.Self.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(availabilityCollection.Status.Self.FailedReason).To(ContainSubstring("instance failed recovering from failed state within time"))
+		Expect(availabilityCollection.Status.Self.FailedSince.Before(&sinceAfter)).To(BeTrue())
+		Expect(sinceBefore.Before(availabilityCollection.Status.Self.FailedSince)).To(BeTrue())
+	})
+
 	It("should add self monitoring status as failed due to lshealthcheck failed state and in timeout", func() {
 		var err error
 		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test2")
@@ -164,6 +217,8 @@ var _ = Describe("Reconcile", func() {
 		Expect(len(availabilityCollection.Status.Instances)).To(Equal(2))
 		Expect(availabilityCollection.Status.Instances[0].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
 		Expect(availabilityCollection.Status.Instances[1].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(availabilityCollection.Status.Instances[0].FailedSince).To(BeNil())
+		Expect(availabilityCollection.Status.Instances[1].FailedSince).To(BeNil())
 	})
 
 	It("should collect lshealthcheck from one successful and one failed (and timeouted) instances", func() {
@@ -198,10 +253,136 @@ var _ = Describe("Reconcile", func() {
 		Expect(availabilityCollection.Status.Instances[0].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
 		Expect(availabilityCollection.Status.Instances[1].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
 		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("problems"))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("timeout - failed recovering from failed state within time"))
+		Expect(availabilityCollection.Status.Instances[0].FailedSince).To(BeNil())
+		Expect(availabilityCollection.Status.Instances[1].FailedSince).ToNot(BeNil())
+	})
+
+	It("should collect lshealthcheck from 2 successful but one timeouted instance", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test3")
+		Expect(err).ToNot(HaveOccurred())
+		op.Config().AvailabilityMonitoring.AvailabilityCollectionNamespace = state.Namespace
+		op.Config().AvailabilityMonitoring.SelfLandscaperNamespace = state.Namespace
+
+		//set lastUpdateTime of LsHealthCheck to recent
+		lsHealthObject := state.GetLsHealthCheck("default")
+		lsHealthObject.LastUpdateTime = v1.Now()
+		Expect(testenv.Client.Update(ctx, lsHealthObject)).To(Succeed())
+
+		lshealthcheck1 := state.GetLsHealthCheckInNamespace("default", fmt.Sprintf("instance1namespace-%s", state.Namespace))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(lshealthcheck1), lshealthcheck1)).To(Succeed())
+		lshealthcheck1.LastUpdateTime = v1.Now()
+		Expect(testenv.Client.Update(ctx, lshealthcheck1)).To(Succeed())
+
+		lshealthcheck2 := state.GetLsHealthCheckInNamespace("default", fmt.Sprintf("instance2namespace-%s", state.Namespace))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(lshealthcheck2), lshealthcheck2)).To(Succeed())
+		lshealthcheck2.LastUpdateTime = v1.Time{Time: v1.Now().Add(time.Minute * -6)}
+		Expect(testenv.Client.Update(ctx, lshealthcheck2)).To(Succeed())
+
+		availabilityCollection := state.GetAvailabilityCollection("availability3")
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(availabilityCollection))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
+		Expect(time.Until(availabilityCollection.Status.LastRun.Time) > time.Minute*-1).To(Equal(true)) //last reported is up-to-data
+		Expect(len(availabilityCollection.Status.Instances)).To(Equal(2))
+		Expect(availabilityCollection.Status.Instances[0].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(availabilityCollection.Status.Instances[1].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("timeout - last update time not recent enough"))
+		Expect(availabilityCollection.Status.Instances[0].FailedSince).To(BeNil())
+		Expect(availabilityCollection.Status.Instances[1].FailedSince).ToNot(BeNil())
+	})
+
+	It("should collect lshealthcheck from one successful and one failed but not timeouted instances", func() {
+		var err error
+		state, err = testenv.InitResources(ctx, "./testdata/reconcile/test3")
+		Expect(err).ToNot(HaveOccurred())
+		op.Config().AvailabilityMonitoring.AvailabilityCollectionNamespace = state.Namespace
+		op.Config().AvailabilityMonitoring.SelfLandscaperNamespace = state.Namespace
+		op.Config().AvailabilityMonitoring.PeriodicCheckInterval.Duration = 0 * time.Second
+
+		//set lastUpdateTime of LsHealthCheck to recent
+		lsHealthObject := state.GetLsHealthCheck("default")
+		lsHealthObject.LastUpdateTime = v1.Now()
+		Expect(testenv.Client.Update(ctx, lsHealthObject)).To(Succeed())
+
+		lshealthcheck1 := state.GetLsHealthCheckInNamespace("default", fmt.Sprintf("instance1namespace-%s", state.Namespace))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(lshealthcheck1), lshealthcheck1)).To(Succeed())
+		lshealthcheck1.LastUpdateTime = v1.Now()
+		Expect(testenv.Client.Update(ctx, lshealthcheck1)).To(Succeed())
+
+		lshealthcheck2 := state.GetLsHealthCheckInNamespace("default", fmt.Sprintf("instance2namespace-%s", state.Namespace))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(lshealthcheck2), lshealthcheck2)).To(Succeed())
+		lshealthcheck2.LastUpdateTime = v1.Now()
+		lshealthcheck2.Status = lsv1alpha1.LsHealthCheckStatusFailed
+		lshealthcheck2.Description = "problems"
+		Expect(testenv.Client.Update(ctx, lshealthcheck2)).To(Succeed())
+
+		availabilityCollection := state.GetAvailabilityCollection("availability3")
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(availabilityCollection))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
+		Expect(time.Until(availabilityCollection.Status.LastRun.Time) > time.Minute*-1).To(Equal(true)) //last reported is up-to-data
+		Expect(len(availabilityCollection.Status.Instances)).To(Equal(2))
+		Expect(availabilityCollection.Status.Instances[0].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(availabilityCollection.Status.Instances[1].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("problems"))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("failed - waiting for timeout"))
+		Expect(availabilityCollection.Status.Instances[0].FailedSince).To(BeNil())
+		Expect(availabilityCollection.Status.Instances[1].FailedSince).ToNot(BeNil())
+
+		// no update availability collection to long failed since
+		since := v1.Time{Time: v1.Now().Add(time.Minute * -6)}
+		availabilityCollection.Status.Instances[1].FailedSince = &since
+		Expect(testenv.Client.Status().Update(ctx, availabilityCollection)).To(Succeed())
+
+		testutils.ShouldReconcile(ctx, ctrl, testutils.RequestFromObject(availabilityCollection))
+		Expect(testenv.Client.Get(ctx, kutil.ObjectKeyFromObject(availabilityCollection), availabilityCollection)).To(Succeed())
+		Expect(time.Until(availabilityCollection.Status.LastRun.Time) > time.Minute*-1).To(Equal(true)) //last reported is up-to-data
+		Expect(len(availabilityCollection.Status.Instances)).To(Equal(2))
+		Expect(availabilityCollection.Status.Instances[0].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(availabilityCollection.Status.Instances[1].Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("problems"))
+		Expect(availabilityCollection.Status.Instances[1].FailedReason).To(ContainSubstring("instance failed recovering from failed state within time"))
+		Expect(availabilityCollection.Status.Instances[0].FailedSince).To(BeNil())
+		Expect(availabilityCollection.Status.Instances[1].FailedSince).ToNot(BeNil())
 	})
 
 })
 var _ = Describe("failed/succeded state handling", func() {
+
+	It("should set status to failed if timeout occured and lshealthcheck is ok", func() {
+		avInstance := &lssv1alpha1.AvailabilityInstance{}
+		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
+			Items: []lsv1alpha1.LsHealthCheck{
+				{
+					Status:         lsv1alpha1.LsHealthCheckStatusOk,
+					LastUpdateTime: v1.Time{Time: v1.Now().Add(time.Minute * -6)},
+				},
+			},
+		}
+		timeout := time.Minute * 5
+		healthwatcher.TransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
+		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(avInstance.FailedReason).To(ContainSubstring("timeout - last update time not recent enough"))
+		Expect(avInstance.FailedSince).ToNot(BeNil())
+	})
+
+	It("should set status to failed if timeout occured and lshealthcheck is failed", func() {
+		avInstance := &lssv1alpha1.AvailabilityInstance{}
+		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
+			Items: []lsv1alpha1.LsHealthCheck{
+				{
+					Status:         lsv1alpha1.LsHealthCheckStatusFailed,
+					LastUpdateTime: v1.Time{Time: v1.Now().Add(time.Minute * -6)},
+				},
+			},
+		}
+		timeout := time.Minute * 5
+		healthwatcher.TransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
+		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
+		Expect(avInstance.FailedReason).To(ContainSubstring("timeout - failed recovering from failed state within time"))
+		Expect(avInstance.FailedSince).ToNot(BeNil())
+	})
+
 	It("should set status to successful if not timeout and lshealthcheck is ok", func() {
 		avInstance := &lssv1alpha1.AvailabilityInstance{}
 		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
@@ -213,11 +394,15 @@ var _ = Describe("failed/succeded state handling", func() {
 			},
 		}
 		timeout := time.Minute * 5
-		healthwatcher.ExportTransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
+		healthwatcher.TransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
 		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
+		Expect(avInstance.FailedReason).To(Equal(""))
+		Expect(avInstance.FailedSince).To(BeNil())
 	})
-	It("should set status to successful if lshealthcheck is failed but not timeouted", func() {
-		avInstance := &lssv1alpha1.AvailabilityInstance{}
+
+	It("should set status to successful if lshealthcheck is failed but not timeouted and not long during error", func() {
+		since := v1.Now()
+		avInstance := &lssv1alpha1.AvailabilityInstance{FailedSince: &since}
 		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
 			Items: []lsv1alpha1.LsHealthCheck{
 				{
@@ -228,40 +413,28 @@ var _ = Describe("failed/succeded state handling", func() {
 			},
 		}
 		timeout := time.Minute * 5
-		healthwatcher.ExportTransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
+		healthwatcher.TransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
 		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusOk)))
 		Expect(avInstance.FailedReason).To(ContainSubstring("to transition to status=Failed"))
+		Expect(avInstance.FailedSince).ToNot(BeNil())
 	})
-	It("should set status to failed if timeout but lshealthcheck is ok", func() {
-		avInstance := &lssv1alpha1.AvailabilityInstance{}
-		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
-			Items: []lsv1alpha1.LsHealthCheck{
-				{
-					Status:         lsv1alpha1.LsHealthCheckStatusOk,
-					LastUpdateTime: v1.Time{Time: v1.Now().Add(time.Minute * -6)},
-				},
-			},
-		}
-		timeout := time.Minute * 5
-		healthwatcher.ExportTransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
-		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
-		Expect(avInstance.FailedReason).To(ContainSubstring("timeout"))
-	})
-	It("should set status to failed if timeout and lshealthcheck is failed", func() {
-		avInstance := &lssv1alpha1.AvailabilityInstance{}
+
+	It("should set status to successful if lshealthcheck is failed but not timeouted and long during error", func() {
+		since := v1.Time{Time: v1.Now().Add(time.Minute * -6)}
+		avInstance := &lssv1alpha1.AvailabilityInstance{FailedSince: &since}
 		lsHealthChecks := &lsv1alpha1.LsHealthCheckList{
 			Items: []lsv1alpha1.LsHealthCheck{
 				{
 					Status:         lsv1alpha1.LsHealthCheckStatusFailed,
 					Description:    "Problem Description",
-					LastUpdateTime: v1.Time{Time: v1.Now().Add(time.Minute * -6)},
+					LastUpdateTime: v1.Now(),
 				},
 			},
 		}
 		timeout := time.Minute * 5
-		healthwatcher.ExportTransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
+		healthwatcher.TransferLsHealthCheckStatusToAvailabilityInstance(avInstance, lsHealthChecks, timeout)
 		Expect(avInstance.Status).To(Equal(string(lsv1alpha1.LsHealthCheckStatusFailed)))
-		Expect(avInstance.FailedReason).To(ContainSubstring("timeout"))
-		Expect(avInstance.FailedReason).To(ContainSubstring("Problem Description"))
+		Expect(avInstance.FailedReason).To(ContainSubstring("instance failed recovering from failed state within time"))
+		Expect(avInstance.FailedSince).ToNot(BeNil())
 	})
 })

--- a/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_availabilitycollections.yaml
+++ b/pkg/crdmanager/crdresources/landscaper-service.gardener.cloud_availabilitycollections.yaml
@@ -61,6 +61,11 @@ spec:
                     failedReason:
                       description: FailedReason is the reason the status is in failed.
                       type: string
+                    failedSince:
+                      description: FailedSince contains the timestamp since the object
+                        is in failed status
+                      format: date-time
+                      type: string
                     name:
                       description: Name is the name of the kubernetes object.
                       type: string
@@ -97,6 +102,11 @@ spec:
                 properties:
                   failedReason:
                     description: FailedReason is the reason the status is in failed.
+                    type: string
+                  failedSince:
+                    description: FailedSince contains the timestamp since the object
+                      is in failed status
+                    format: date-time
                     type: string
                   name:
                     description: Name is the name of the kubernetes object.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix health checks such that it is recognised when some pod of a landscaper instance is down, this results in an alert.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- fix error in health checks
```
