### PR TITLE
Fix cleanup of NamespacerRegistrations

### DIFF
--- a/charts/sidecar-rbac/templates/clusterrole-controller.yaml
+++ b/charts/sidecar-rbac/templates/clusterrole-controller.yaml
@@ -20,6 +20,12 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - landscaper.gardener.cloud
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request fixes the following issue.

- On the resource cluster of a landscaper instance, create a NamespaceRegistration.
- In the corresponding namespace, create an Installation.
- Add the annotation `landscaper-service.gardener.cloud/on-delete-strategy=delete-all-installations-without-uninstall` to the NamespaceRegistration, see [Deleting NamespaceRegistrations](https://github.com/gardener/landscaper-service/blob/main/docs/usage/Namespaceregistration.md#deleting-namespaceregistrations)
- Delete the NamespaceRegistration.
- The controller of NamespaceRegistrations should first cleanup the Landscaper resources in the namespace before it deletes the NamespaceRegistration itself. However, it does not have sufficient permissions for the cleanup. Therefore, the NamespaceRegistration will fail with an error message in its status like this: *installations.landscaper.gardener.cloud is forbidden: User "system:serviceaccount:ls-system:sidecar" cannot list resource "installations" in API group "landscaper.gardener.cloud" in the namespace ...*

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
- bugfix concerning the deletion of NamespaceRegistrations
```
