### PR TITLE
Cluster-wide read permissions for landscaper resources

### DIFF
--- a/pkg/controllers/subjectsync/controller.go
+++ b/pkg/controllers/subjectsync/controller.go
@@ -141,6 +141,11 @@ func (c *Controller) createOrUpdateUserClusterRole(ctx context.Context) error {
 			Resources: []string{"subjectlists"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			APIGroups: []string{"landscaper.gardener.cloud"},
+			Resources: []string{"*"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	}
 
 	role := &rbacv1.ClusterRole{


### PR DESCRIPTION
**What this PR does / why we need it**:

This pull request grants the users of landscaper instances **cluster-wide** read permissions for landscaper resources on their resource cluster.

Currently, only a command that is restricted to a namespace works, for example:

```shell
kubectl get installations -n cu-example
``` 

With this pull request also the following works:

```shell
kubectl get installations --all-namespaces
``` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Cluster-wide read permissions for landscaper resources.
```
