### PR TITLE
upgrade resource cluster kubernetes version to 1.26

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -22,7 +22,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.25"
+    "version": "1.26"
   },
   "maintenance": {
     "timeWindow": {

--- a/hack/setup-testenv.sh
+++ b/hack/setup-testenv.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-K8S_VERSION="1.25.x"
+K8S_VERSION="1.26.x"
 
 echo "> Setup Test Environment for K8s Version ${K8S_VERSION}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

upgrade resource cluster kubernetes version to 1.26

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
- upgrade resource cluster kubernetes version to 1.26
```
