### PR TITLE
add read access to custom resource definitions

### DIFF
--- a/pkg/controllers/subjectsync/controller.go
+++ b/pkg/controllers/subjectsync/controller.go
@@ -130,8 +130,8 @@ func (c *Controller) reconcile(ctx context.Context, subjectList *lssv1alpha1.Sub
 	return reconcile.Result{}, nil
 }
 
-func (c *Controller) createOrUpdateUserClusterRole(ctx context.Context) error {
-	rules := []rbacv1.PolicyRule{
+func GetUserPolicyRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
 		{
 			APIGroups: []string{""},
 			Resources: []string{"namespaces"},
@@ -147,8 +147,15 @@ func (c *Controller) createOrUpdateUserClusterRole(ctx context.Context) error {
 			Resources: []string{"*"},
 			Verbs:     []string{"get", "list", "watch"},
 		},
+		{
+			APIGroups: []string{"apiextensions.k8s.io"},
+			Resources: []string{"customresourcedefinitions"},
+			Verbs:     []string{"get", "list", "watch"},
+		},
 	}
+}
 
+func (c *Controller) createOrUpdateUserClusterRole(ctx context.Context) error {
 	role := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: USER_CLUSTER_ROLE,
@@ -156,7 +163,7 @@ func (c *Controller) createOrUpdateUserClusterRole(ctx context.Context) error {
 	}
 
 	_, err := kutils.CreateOrUpdate(ctx, c.Client(), role, func() error {
-		role.Rules = rules
+		role.Rules = GetUserPolicyRules()
 		return nil
 	})
 	if err != nil {

--- a/pkg/controllers/subjectsync/reconcile_test.go
+++ b/pkg/controllers/subjectsync/reconcile_test.go
@@ -6,6 +6,7 @@ package subjectsync_test
 
 import (
 	"context"
+	"reflect"
 
 	kutil "github.com/gardener/landscaper/controller-utils/pkg/kubernetes"
 	"github.com/gardener/landscaper/controller-utils/pkg/logging"
@@ -155,6 +156,14 @@ var _ = Describe("Reconcile", func() {
 		Expect(updatedUserRoleBinding.Subjects[2].Kind).To(Equal("ServiceAccount"))
 		Expect(updatedUserRoleBinding.Subjects[2].Name).To(Equal("testserviceaccount"))
 		Expect(updatedUserRoleBinding.Subjects[2].Namespace).To(Equal(subjectsync.LS_USER_NAMESPACE))
+
+		clusterRole := rbacv1.ClusterRole{}
+		Expect(testenv.Client.Get(ctx, types.NamespacedName{Name: subjectsync.USER_CLUSTER_ROLE}, &clusterRole)).To(Succeed())
+
+		expectedRules := subjectsync.GetUserPolicyRules()
+
+		Expect(len(clusterRole.Rules)).To(Equal(len(expectedRules)))
+		Expect(reflect.DeepEqual(clusterRole.Rules, expectedRules)).To(BeTrue())
 	})
 
 	It("should skip unknown/erroneous subjects", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

For certain tools/IDEs read access to custom resource definitions is needed.
This PR gives all Landscaper users read access to custom resource definitions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add read access to custom resource definitions for Lndscaper users
```
