### PR TITLE
Improve default scheduling

### DIFF
--- a/pkg/controllers/landscaperdeployments/scheduling/sort.go
+++ b/pkg/controllers/landscaperdeployments/scheduling/sort.go
@@ -36,9 +36,6 @@ func SortServiceTargetConfigs(configs []*lssv1alpha1.ServiceTargetConfig) {
 		l := configs[i]
 		r := configs[j]
 
-		lPrio := l.Spec.Priority / int64(len(l.Status.InstanceRefs)+1)
-		rPrio := r.Spec.Priority / int64(len(r.Status.InstanceRefs)+1)
-
-		return lPrio > rPrio
+		return l.Spec.Priority*int64(len(r.Status.InstanceRefs)+1) > r.Spec.Priority*int64(len(l.Status.InstanceRefs)+1)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The default scheduling algorithm to assign a landscaper instance to a target cluster selects the target cluster where `prioTarget/(numOfClustersOnTarget+1)` is highest. Because this check is done by an integer division, the result becomes always 0 when `(numOfClustersOnTarget+1) > 2*prioTarget`. The current check between two targets was:

`prioTarget1/(numOfClustersOnTarget1+1) > prioTarget2/(numOfClustersOnTarget2+1)`

This PR changes this to the equal conditions without the problem of rounding errors:

`prioTarget1 * (numOfClustersOnTarget2+1) > prioTarget2*(numOfClustersOnTarget1+1)`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- improve default scheduling of landscaper instances to target clusters
```
