### PR TITLE
Update deprecated gardenlinux to 1312.3.0

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -9,7 +9,7 @@
       "type": "n1-standard-2",
       "image": {
         "name": "gardenlinux",
-        "version": "1312.1.0"
+        "version": "1312.3.0"
       }
     },
     "volume": {

--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -126,7 +126,7 @@ deployItems:
                       type: {{ dig "shootConfig" "workers" "machine" "type" "n1-standard-2" .imports  }}
                       image:
                         name: {{ dig "shootConfig" "workers" "machine" "image" "name" "gardenlinux" .imports }}
-                        version: {{ dig "shootConfig" "workers" "machine" "image" "version" "1312.1.0" .imports }}
+                        version: {{ dig "shootConfig" "workers" "machine" "image" "version" "1312.3.0" .imports }}
                     zones:
                       - {{ .imports.shootConfig.provider.zone }}
                     cri:

--- a/.landscaper/landscaper-instance/test/internal-dataplane/values-shoot.yaml
+++ b/.landscaper/landscaper-instance/test/internal-dataplane/values-shoot.yaml
@@ -27,7 +27,7 @@ imports:
           "type": "n1-standard-2",
           "image": {
             "name": "gardenlinux",
-            "version": "1312.1.0"
+            "version": "1312.3.0"
           }
         },
         "volume": {


### PR DESCRIPTION
**What this PR does / why we need it**:
[gardenlinux 1312.1.0 has been deprecated](https://pages.github.tools.sap/kubernetes/gardener/docs/landscapes/live/pam/#gardenlinux)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Update to gardenlinux to 1312.3.0
```
