### PR TITLE
Upgrade resource cluster to k8s 1.27

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -22,7 +22,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.26",
+    "version": "1.27",
     "kubeAPIServer": {
       "encryptionConfig": {
         "resources": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrade resource cluster to k8s 1.27

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Upgrade resource cluster to k8s 1.27
```
