### PR TITLE
Update integration tests running with go 1.22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-resources: docker-images component
 build-int-test-image:
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	@docker buildx build --platform linux/amd64 integration-test/docker -t europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.21.9-alpine3.19 --push
+	@docker buildx build --platform linux/amd64 integration-test/docker -t europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.22.2-alpine3.19 --push
 	- docker buildx rm project-v3-builder
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
new integration test image @ europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
