### PR TITLE
Kubernetes version 1.28 for shoot clusters

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -27,7 +27,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.27",
+    "version": "1.28",
     "kubeAPIServer": {
       "encryptionConfig": {
         "resources": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubernetes version 1.28 for shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Kubernetes version 1.28 for shoot clusters.
```
