### PR TITLE
add new parameter shootConfigurationUseMergeOverwrite

### DIFF
--- a/.landscaper/blueprint/blueprint.yaml
+++ b/.landscaper/blueprint/blueprint.yaml
@@ -94,6 +94,12 @@ imports:
     schema:
       type: object
 
+  - name: shootConfigurationUseMergeOverwrite
+    required: false
+    type: data
+    schema:
+      type: boolean
+
 deployExecutions:
   - name: deploy-execution
     file: /deploy-execution.yaml

--- a/.landscaper/blueprint/deploy-execution.yaml
+++ b/.landscaper/blueprint/deploy-execution.yaml
@@ -70,7 +70,11 @@ deployItems:
 
           {{ $shootConfiguration := ( fromJson (toString (readFile "./shoot-config.json"))) }}
           {{ if .imports.shootConfiguration }}
+          {{ if eq true .imports.shootConfigurationUseMergeOverwrite }}
+          {{ $shootConfiguration := mergeOverwrite $shootConfiguration .imports.shootConfiguration }}
+          {{ else }}
           {{ $shootConfiguration := merge $shootConfiguration .imports.shootConfiguration }}
+          {{ end }}
           {{ end }}
           shootConfiguration:
 {{ toYaml $shootConfiguration | indent 12 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the new optional parameter `shootConfigurationUseMergeOverwrite` to the landscaper-service blueprint.
When this parameter is set and is set to true, the sprig `mergeOverwrite` function will be used instead of `merge`.

The difference is:

- `merge`: "Merge two or more dictionaries into one, giving precedence to the dest dictionary"
- `mergeOverwrite`: "Merge two or more dictionaries into one, giving precedence from right to left, effectively overwriting values in the dest dictionary"

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add new optional parameter `shootConfigurationUseMergeOverwrite` which controls the behaviour of the shoot configration merge operation when deploying the landscaper-service.
```
