### PR TITLE
Validate deployers of a LandscaperDeployment

### DIFF
--- a/pkg/apis/validation/landscaperdeployment.go
+++ b/pkg/apis/validation/landscaperdeployment.go
@@ -7,11 +7,11 @@ package validation
 import (
 	"fmt"
 
-	"github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
-
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
 )
 
 const (
@@ -58,6 +58,8 @@ func validateLandscaperDeploymentSpec(spec *v1alpha1.LandscaperDeploymentSpec, f
 	if spec.DataPlane != nil {
 		allErrs = append(allErrs, ValidateDataPlane(spec.DataPlane, fldPath.Child("dataPlane"))...)
 	}
+
+	allErrs = append(allErrs, ValidateLandscaperConfiguration(&spec.LandscaperConfiguration, fldPath.Child("landscaperConfiguration"))...)
 
 	return allErrs
 }

--- a/pkg/apis/validation/landscaperdeployment_test.go
+++ b/pkg/apis/validation/landscaperdeployment_test.go
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
+	"github.com/gardener/landscaper-service/pkg/apis/validation"
+)
+
+func createLandscaperDeployment() *v1alpha1.LandscaperDeployment {
+	return &v1alpha1.LandscaperDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-landscaper-deployment",
+			Namespace: "test-namespace",
+		},
+		Spec: v1alpha1.LandscaperDeploymentSpec{
+			TenantId: "test-id1",
+			Purpose:  "test-purpose",
+		},
+	}
+}
+
+var _ = Describe("Validation of LandscaperDeployments", func() {
+	It("should accept supported deployers", func() {
+		ld := createLandscaperDeployment()
+		ld.Spec.LandscaperConfiguration.Deployers = []string{"manifest", "helm", "container"}
+		errList := validation.ValidateLandscaperDeployment(ld, nil)
+		Expect(errList).To(BeEmpty())
+	})
+
+	It("should accept default deployers", func() {
+		ld := createLandscaperDeployment()
+		ld.Spec.LandscaperConfiguration.Deployers = nil
+		errList := validation.ValidateLandscaperDeployment(ld, nil)
+		Expect(errList).To(BeEmpty())
+	})
+
+	It("should reject unsupported deployers", func() {
+		ld := createLandscaperDeployment()
+		ld.Spec.LandscaperConfiguration.Deployers = []string{"fantasy-deployer"}
+		errList := validation.ValidateLandscaperDeployment(ld, nil)
+		Expect(errList).To(HaveLen(1))
+		Expect(errList[0].Type).To(Equal(field.ErrorTypeNotSupported))
+		Expect(errList[0].Field).To(Equal("spec.landscaperConfiguration.deployers"))
+	})
+})

--- a/pkg/apis/validation/shared.go
+++ b/pkg/apis/validation/shared.go
@@ -5,6 +5,8 @@
 package validation
 
 import (
+	"slices"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/gardener/landscaper-service/pkg/apis/core/v1alpha1"
@@ -60,6 +62,22 @@ func ValidateDataPlane(dataPlane *v1alpha1.DataPlane, fldPath *field.Path) field
 
 	if dataPlane.SecretRef != nil {
 		allErrs = append(allErrs, ValidateSecretReference(dataPlane.SecretRef, fldPath.Child("secretRef"))...)
+	}
+
+	return allErrs
+}
+
+var supportedDeployers = []string{"helm", "manifest", "container"}
+
+func ValidateLandscaperConfiguration(landscaperConfiguration *v1alpha1.LandscaperConfiguration, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(landscaperConfiguration.Deployers) != 0 {
+		for _, deployer := range landscaperConfiguration.Deployers {
+			if !slices.Contains(supportedDeployers, deployer) {
+				allErrs = append(allErrs, field.NotSupported(fldPath, deployer, supportedDeployers))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/validation/shared.go
+++ b/pkg/apis/validation/shared.go
@@ -75,7 +75,7 @@ func ValidateLandscaperConfiguration(landscaperConfiguration *v1alpha1.Landscape
 	if len(landscaperConfiguration.Deployers) != 0 {
 		for _, deployer := range landscaperConfiguration.Deployers {
 			if !slices.Contains(supportedDeployers, deployer) {
-				allErrs = append(allErrs, field.NotSupported(fldPath, deployer, supportedDeployers))
+				allErrs = append(allErrs, field.NotSupported(fldPath.Child("deployers"), deployer, supportedDeployers))
 			}
 		}
 	}

--- a/pkg/apis/validation/validation_suite_test.go
+++ b/pkg/apis/validation/validation_suite_test.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2024 "SAP SE or an SAP affiliate company and Gardener contributors"
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/landscaper-service/test/utils/envtest"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Test Suite")
+}
+
+var (
+	testenv *envtest.Environment
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	projectRoot := filepath.Join("../../../")
+	testenv, err = envtest.NewEnvironment(projectRoot)
+	Expect(err).ToNot(HaveOccurred())
+
+	_, err = testenv.Start()
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testenv.Stop()).ToNot(HaveOccurred())
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

The validation of LandscaperDeployments has been extended to ensure that only supported deployers ("helm", "manifest", "container") can be specified in the landscaper configuration (field `spec.landscaperConfiguration.deployers`).

Background: some users misunderstood the meaning of the deployers field and set their email address as value.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- The validation of LandscaperDeployments has been extended to ensure that only supported deployers can be specified in the landscaper configuration.
```
