### PR TITLE
Support mock deployer

### DIFF
--- a/pkg/apis/validation/shared.go
+++ b/pkg/apis/validation/shared.go
@@ -67,7 +67,7 @@ func ValidateDataPlane(dataPlane *v1alpha1.DataPlane, fldPath *field.Path) field
 	return allErrs
 }
 
-var supportedDeployers = []string{"helm", "manifest", "container"}
+var supportedDeployers = []string{"helm", "manifest", "container", "mock"}
 
 func ValidateLandscaperConfiguration(landscaperConfiguration *v1alpha1.LandscaperConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the validation of LandscaperDeployments so that also the mock deployer is supported - in addition to helm, manifest, and container deployer. This is needed because the mock deployer is used by tests. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Support mock deployer.
```
