### PR TITLE
Add issuer annotation to resource clusters

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -83,6 +83,7 @@ deployItems:
               annotations:
                 shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds: '30'
                 gardener.cloud/operation: reconcile
+                authentication.gardener.cloud/issuer: managed
             {{ if .imports.labels }}
               labels:
 {{ toYaml .imports.labels | indent 16 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the issuer annotation `authentication.gardener.cloud/issuer: managed` to the resource clusters of landscaper instances, see [Managed Service Account Issuer](https://gardener.cloud/docs/gardener/shoot_serviceaccounts/#managed-service-account-issuer). It is a prerequisite for [OIDC Targets](https://github.com/gardener/landscaper/pull/1242).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Prepare support for OIDC Targets
```
