### PR TITLE
Update shoots: kubernetes 1.29, gardenlinux 1443.10.0

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -14,7 +14,7 @@
       "type": "n1-standard-2",
       "image": {
         "name": "gardenlinux",
-        "version": "1312.7.0"
+        "version": "1443.10.0"
       }
     },
     "volume": {
@@ -27,7 +27,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.28",
+    "version": "1.29",
     "kubeAPIServer": {
       "encryptionConfig": {
         "resources": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Update shoot clusters:
- kubernetes 1.29,
- gardenlinux 1443.10.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Update kubernetes version of shoots to 1.29
- Update gardenlinux version of shoots to 1443.10.0
```
