### PR TITLE
Extend landscaper user role: permission to maintain ServiceAccounts in customer namespaces

### DIFF
--- a/pkg/controllers/subjectsync/roledefinition.go
+++ b/pkg/controllers/subjectsync/roledefinition.go
@@ -81,6 +81,11 @@ func GetUserRoleDefinition(namespace string) *RoleDefinition {
 				Resources: []string{"secrets", "configmaps"},
 				Verbs:     []string{"*"},
 			},
+			{
+				APIGroups: []string{""},
+				Resources: []string{"serviceaccounts"},
+				Verbs:     []string{"*"},
+			},
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR extends the landscaper user role `landscaper-service:landscaper-user` which exists in every customer namespace `cu-...`.  The user gets the additional permission to maintain ServiceAccounts.

Reason: an OIDC Target must reference a ServiceAccount in the same namespace. Therefore, we must allow users to create ServiceAccounts in the same namespaces where Targets are created. (Currently, a user can create ServiceAccounts only in the `ls-user` namespace.)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Extension of the landscaper-user role to include the permissions to maintain ServiceAccounts.
```
