### PR TITLE
Update kubernetes version of shoot clusters to 1.31

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -27,7 +27,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.30",
+    "version": "1.31",
     "kubeAPIServer": {
       "encryptionConfig": {
         "resources": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Update kubernetes version of shoot clusters to 1.31

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Update kubernetes version of shoot clusters to 1.31
```
