### PR TITLE
chore: update to golang:1.24.5-alpine3.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-resources: docker-images component
 build-int-test-image:
 	- docker buildx create --name project-v3-builder
 	docker buildx use project-v3-builder
-	@docker buildx build --platform linux/amd64 integration-test/docker -t europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.24.4-alpine3.21 --push
+	@docker buildx build --platform linux/amd64 integration-test/docker -t europe-docker.pkg.dev/sap-gcp-cp-k8s-stable-hub/landscaper/integration-test:1.24.5-alpine3.22 --push
 	- docker buildx rm project-v3-builder
 
 

--- a/integration-test/docker/Dockerfile
+++ b/integration-test/docker/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.24.4-alpine3.21@sha256:56a23791af0f77c87b049230ead03bd8c3ad41683415ea4595e84ce7eada121a
+FROM golang:1.24.5-alpine3.22@sha256:ddf52008bce1be455fe2b22d780b6693259aaf97b16383b6372f4b22dd33ad66
 
 RUN apk add --no-cache --no-progress \
     bash \


### PR DESCRIPTION
**What this PR does / why we need it**:

Update integration test base image to `golang:1.24.5-alpine3.22`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Update integration test base image to `golang:1.24.5-alpine3.22`
```
