### PR TITLE
fix: remove field enableStaticTokenKubeconfig

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -145,7 +145,6 @@ deployItems:
               secretBindingName: {{ .imports.secretBindingName }}
               kubernetes:
                 version: "{{ .imports.shootConfig.kubernetes.version }}"
-                enableStaticTokenKubeconfig: false
                 kubeAPIServer:
                   {{ if ((.imports.shootConfig.kubernetes.kubeAPIServer).oidcConfig) }}
                   oidcConfig:


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove obsolete field enableStaticTokenKubeconfig from shoot manifest, when creating a landscaper instance.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
- Remove obsolete field enableStaticTokenKubeconfig from shoot manifest, when creating a landscaper instance.
```
