### PR TITLE
Revert "chore: update kubernetes version of shoots to 1.32"

### DIFF
--- a/.landscaper/blueprint/shoot-config.json
+++ b/.landscaper/blueprint/shoot-config.json
@@ -27,7 +27,7 @@
     "maxUnavailable": 0
   },
   "kubernetes": {
-    "version": "1.32",
+    "version": "1.31",
     "kubeAPIServer": {
       "encryptionConfig": {
         "resources": [


### PR DESCRIPTION
Reverts gardener/landscaper-service#603

We postpone the update to kubernetes 1.32 until we have a replacement for the oidcConfig in shoots. (Field `spec.kubernetes.kubeAPIServer.oidcConfig` is forbidden in a shoot.yaml in kubernetes version >= 1.32.)