### PR TITLE
feat: structured authentication

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -60,10 +60,10 @@ deployItems:
                       audienceMatchPolicy: MatchAny
                     claimMappings:
                       username:
-                        claim: email
+                        claim: "{{ default "email" .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.usernameClaim }}"
                         prefix: ""
                       groups:
-                        claim: groups
+                        claim: "{{ default "groups" .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.groupsClaim }}"
                         prefix: ""
         {{ end }}
 

--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -40,6 +40,33 @@ deployItems:
       deleteTimeout: 30m
 
       manifests:
+      {{ if .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig }}
+        - policy: manage
+          manifest:
+            apiVersion: v1
+            kind: ConfigMap
+            metadata:
+              name: "{{ .imports.name }}-authentication-config"
+              namespace: "{{ .imports.namespace }}"
+            data:
+              config.yaml: |
+                apiVersion: apiserver.config.k8s.io/v1beta1
+                kind: AuthenticationConfiguration
+                jwt:
+                  - issuer:
+                      url: "{{ .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.issuerURL }}"
+                      audiences:
+                        - "{{ .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig.clientID }}"
+                      audienceMatchPolicy: MatchAny
+                    claimMappings:
+                      username:
+                        claim: email
+                        prefix: ""
+                      groups:
+                        claim: groups
+                        prefix: ""
+        {{ end }}
+
         {{ if .imports.auditPolicy }}
         - policy: manage
           manifest:
@@ -146,10 +173,6 @@ deployItems:
               kubernetes:
                 version: "{{ .imports.shootConfig.kubernetes.version }}"
                 kubeAPIServer:
-                  {{ if ((.imports.shootConfig.kubernetes.kubeAPIServer).oidcConfig) }}
-                  oidcConfig:
-{{ toYaml .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig | indent 20 }}
-                  {{ end }}
                   {{ if .imports.auditPolicy }}
                   auditConfig:
                     auditPolicy:

--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -173,6 +173,10 @@ deployItems:
               kubernetes:
                 version: "{{ .imports.shootConfig.kubernetes.version }}"
                 kubeAPIServer:
+                  {{ if .imports.shootConfig.kubernetes.kubeAPIServer.oidcConfig }}
+                  structuredAuthentication:
+                    configMapName: "{{ .imports.name }}-authentication-config"
+                  {{ end }}
                   {{ if .imports.auditPolicy }}
                   auditConfig:
                     auditPolicy:


### PR DESCRIPTION
**What this PR does / why we need it**:

For shoots with kubernetes version >= 1.32, the field `spec.kubernetes.kubeAPIServer.oidcConfig` is no longer allowed. In the past, we have used this field for the shoot clusters created by the landscaper-service. With this pull request, we use structured authentication as a replacement for the oidcConfig.

Changes:
- Besides the shoot, we create a ConfigMap on the Garden cluster. The ConfigMap contains an AuthenticationConfiguration.
- The shoot manifest contains a reference to the ConfigMap.
- The old oidcConfig is removed from the shoot manifest.

References:
- [Gardener: Structured Authentication](https://pages.github.tools.sap/kubernetes/gardener/docs/landscapes/live/gardener/shoot/shoot_access/#structured-authentication)
- [Gardener: Migrating from OIDC to Structured Authentication Config](https://gardener.cloud/docs/gardener/shoot/shoot_access/#migrating-from-oidc-to-structured-authentication-config)
- [Kubernetes reference: Issuer](https://kubernetes.io/docs/reference/config-api/apiserver-config.v1alpha1/#apiserver-k8s-io-v1alpha1-Issuer)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Structured authentication for the shoots of landscaper instances.
```
