### PR TITLE
Revert "chore(deps): bump github.com/go-viper/mapstructure/v2 from 2.3.0 to 2.4.0 in /integration-test"

### DIFF
--- a/integration-test/go.mod
+++ b/integration-test/go.mod
@@ -155,7 +155,7 @@ require (
 	github.com/go-openapi/swag v0.23.1 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/go-test/deep v1.1.1 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.3.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/goccy/go-yaml v1.17.1 // indirect

--- a/integration-test/go.sum
+++ b/integration-test/go.sum
@@ -438,8 +438,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1v
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9LvH92wZUgs=
-github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/go-viper/mapstructure/v2 v2.3.0 h1:27XbWsHIqhbdR5TIC911OfYvgSaW93HM+dX7970Q7jk=
+github.com/go-viper/mapstructure/v2 v2.3.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=


### PR DESCRIPTION
Reverts gardener/landscaper-service#634

Integration tests faile with errors:
```
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/gcc -m64 -Wl,-z,now -Wl,-z,nocopyreloc -Wl,--build-id=0xa73caf204ea5c7662de7f4ad586e0ed83ae4a038 -o $WORK/b001/integration.test -rdynamic -Wl,--compress-debug-sections=zlib /tmp/go-link-2928713693/go.o /tmp/go-link-2928713693/000000.o /tmp/go-link-2928713693/000001.o /tmp/go-link-2928713693/000002.o /tmp/go-link-2928713693/000003.o /tmp/go-link-2928713693/000004.o /tmp/go-link-2928713693/000005.o /tmp/go-link-2928713693/000006.o /tmp/go-link-2928713693/000007.o /tmp/go-link-2928713693/000008.o /tmp/go-link-2928713693/000009.o /tmp/go-link-2928713693/000010.o /tmp/go-link-2928713693/000011.o /tmp/go-link-2928713693/000012.o /tmp/go-link-2928713693/000013.o /tmp/go-link-2928713693/000014.o /tmp/go-link-2928713693/000015.o /tmp/go-link-2928713693/000016.o /tmp/go-link-2928713693/000017.o /tmp/go-link-2928713693/000018.o /tmp/go-link-2928713693/000019.o /tmp/go-link-2928713693/000020.o /tmp/go-link-2928713693/000021.o /tmp/go-link-2928713693/000022.o /tmp/go-link-2928713693/000023.o /tmp/go-link-2928713693/000024.o /tmp/go-link-2928713693/000025.o /tmp/go-link-2928713693/000026.o /tmp/go-link-2928713693/000027.o /tmp/go-link-2928713693/000028.o -O2 -g -lresolv -O2 -g -lpthread -O2 -g -O2 -g -ldl -O2 -g -no-pie
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/go-link-2928713693/go.o: in function `local.ocm.software/ocm/api/ocm/extensions/accessmethods/git.(*AccessSpec).AccessMethod':
go.go:(.text+0x2ffef6c): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetLoggingContext(github.com/mandelsoft/logging.ContextProvider) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.interface { LoggingContext() github.com/mandelsoft/logging.Context }]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2ffefb9): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCredentialContext(ocm.software/ocm/api/credentials/internal.ContextProvider) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.interface { CredentialsContext() ocm.software/ocm/api/credentials/internal.Context }]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2ffefe6): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetURL(string) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.string]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2fff013): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetRef(string) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.string]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2fff041): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCommit(string) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.string]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2fff0a1): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCachingFileSystem(github.com/mandelsoft/vfs/pkg/vfs.FileSystem) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.5e4391f80d098dccf2ba8c4e55eaf1563e3d119b98a702896c7e6f813a98e8e0]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x2fff1d0): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCredentials(ocm.software/ocm/api/credentials/internal.Credentials) },*ocm.software/ocm/api/utils/blobaccess/git.Options,go.shape.interface { Credentials(ocm.software/ocm/api/credentials/internal.Context, ...ocm.software/ocm/api/credentials/internal.CredentialsSource) (ocm.software/ocm/api/credentials/internal.Credentials, error); ExistsProperty(string) bool; GetProperty(string) string; Properties() ocm.software/ocm/api/utils/misc.Properties; PropertyNames() github.com/mandelsoft/goutils/set.Set[string] }]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/go-link-2928713693/go.o: in function `local.ocm.software/ocm/api/ocm/extensions/accessmethods/maven.(*AccessSpec).AccessMethod.func1':
go.go:(.text+0x321b4a8): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCredentialContext(ocm.software/ocm/api/credentials/internal.ContextProvider) },*ocm.software/ocm/api/utils/blobaccess/maven.Options,go.shape.interface { CredentialsContext() ocm.software/ocm/api/credentials/internal.Context }]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x321b4ed): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetLoggingContext(github.com/mandelsoft/logging.ContextProvider) },*ocm.software/ocm/api/utils/blobaccess/maven.Options,go.shape.interface { LoggingContext() github.com/mandelsoft/logging.Context }]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: go.go:(.text+0x321b541): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetCachingFileSystem(github.com/mandelsoft/vfs/pkg/vfs.FileSystem) },*ocm.software/ocm/api/utils/blobaccess/maven.Options,go.shape.5e4391f80d098dccf2ba8c4e55eaf1563e3d119b98a702896c7e6f813a98e8e0]'
/usr/lib/gcc/x86_64-alpine-linux-musl/14.2.0/../../../../x86_64-alpine-linux-musl/bin/ld: /tmp/go-link-2928713693/go.o: in function `local.ocm.software/ocm/api/ocm/extensions/accessmethods/npm.newMethod.func1':
go.go:(.text+0x3222234): undefined reference to `github.com/mandelsoft/goutils/optionutils.WithGenericOption[go.shape.interface { SetDataContext(ocm.software/ocm/api/datacontext.Context) },*ocm.software/ocm/api/utils/blobaccess/npm.Options,go.shape.f226dda8c0e9cd22009734da35ee76a990e343f90672b37974117010329c4e83]'
collect2: error: ld returned 1 exit status
```