### PR TITLE
feat: migration from secretbinding to credentialsbinding

### DIFF
--- a/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
+++ b/.landscaper/landscaper-instance/blueprint/shoot/deploy-execution.yaml
@@ -169,7 +169,8 @@ deployItems:
                 services: 100.64.0.0/13
               cloudProfileName: {{ .imports.shootConfig.provider.type }}
               region: {{ .imports.shootConfig.region }}
-              secretBindingName: {{ .imports.secretBindingName }}
+              secretBindingName: null
+              credentialsBindingName: {{ .imports.secretBindingName }}
               kubernetes:
                 version: "{{ .imports.shootConfig.kubernetes.version }}"
                 kubeAPIServer:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Migrates the shoot clusters, managed by the landscaper-service from secretBinding to credentialsBinding, as described in [SecretBinding to CredentialsBinding Migration](https://pages.github.tools.sap/kubernetes/gardener/docs/landscapes/live/gardener/shoot-operations/secretbinding-to-credentialsbinding-migration/).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Migration of shoot clusters, managed by the landscaper-service, from secretBinding to credentialsBinding.
```
